### PR TITLE
Bugfix pets' owner-related behaviors registration

### DIFF
--- a/src/main/java/dev/breeze/settlements/entities/EntityModuleController.java
+++ b/src/main/java/dev/breeze/settlements/entities/EntityModuleController.java
@@ -4,6 +4,7 @@ import com.mojang.serialization.Codec;
 import dev.breeze.settlements.entities.cats.VillagerCat;
 import dev.breeze.settlements.entities.cats.memories.CatMemoryType;
 import dev.breeze.settlements.entities.cats.sensors.CatNearbyItemsSensor;
+import dev.breeze.settlements.entities.cats.sensors.CatOwnerSensor;
 import dev.breeze.settlements.entities.cats.sensors.CatSensorType;
 import dev.breeze.settlements.entities.villagers.BaseVillager;
 import dev.breeze.settlements.entities.villagers.events.VillagerRestockEvent;
@@ -208,6 +209,7 @@ public class EntityModuleController extends BaseModuleController {
         WolfSensorType.NEARBY_SHEEP = registerSensor(WolfSensorType.REGISTRY_KEY_NEARBY_SHEEP, WolfNearbySheepSensor::new);
 
         // Cat sensors
+        CatSensorType.OWNER = registerSensor(CatSensorType.REGISTRY_KEY_OWNER, CatOwnerSensor::new);
         CatSensorType.NEARBY_ITEMS = registerSensor(CatSensorType.REGISTRY_KEY_NEARBY_ITEMS, CatNearbyItemsSensor::new);
 
         // Re-freeze registry

--- a/src/main/java/dev/breeze/settlements/entities/EntityModuleController.java
+++ b/src/main/java/dev/breeze/settlements/entities/EntityModuleController.java
@@ -203,6 +203,7 @@ public class EntityModuleController extends BaseModuleController {
         VillagerSensorType.IS_MEAL_TIME = registerSensor(VillagerSensorType.REGISTRY_KEY_IS_MEAL_TIME, VillagerMealTimeSensor::new);
 
         // Wolf sensors
+        WolfSensorType.OWNER = registerSensor(WolfSensorType.REGISTRY_KEY_OWNER, WolfOwnerSensor::new);
         WolfSensorType.NEARBY_ITEMS = registerSensor(WolfSensorType.REGISTRY_KEY_NEARBY_ITEMS, WolfNearbyItemsSensor::new);
         WolfSensorType.NEARBY_SNIFFABLE_ENTITIES = registerSensor(WolfSensorType.REGISTRY_KEY_NEARBY_SNIFFABLE_ENTITIES, WolfSniffableEntitiesSensor::new);
         WolfSensorType.NEAREST_FENCE_AREA = registerSensor(WolfSensorType.REGISTRY_KEY_NEAREST_FENCE_AREA, WolfFenceAreaSensor::new);

--- a/src/main/java/dev/breeze/settlements/entities/cats/VillagerCat.java
+++ b/src/main/java/dev/breeze/settlements/entities/cats/VillagerCat.java
@@ -170,6 +170,7 @@ public class VillagerCat extends Cat {
      */
     @Override
     @Nonnull
+    @SuppressWarnings("unchecked")
     public Brain<Cat> getBrain() {
         return (Brain<Cat>) super.getBrain();
     }
@@ -304,7 +305,7 @@ public class VillagerCat extends Cat {
             return;
         }
 
-        LogUtil.info("Owner detected, refreshing cat brain goals!");
+        LogUtil.info("Owner detected, refreshing cat brain goals");
         this.refreshBrain(this.level.getMinecraftWorld());
     }
 

--- a/src/main/java/dev/breeze/settlements/entities/cats/VillagerCat.java
+++ b/src/main/java/dev/breeze/settlements/entities/cats/VillagerCat.java
@@ -42,7 +42,6 @@ import net.minecraft.world.level.Level;
 import org.bukkit.Location;
 import org.bukkit.craftbukkit.v1_19_R2.CraftWorld;
 import org.bukkit.event.entity.CreatureSpawnEvent;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -188,7 +187,7 @@ public class VillagerCat extends Cat {
         return Brain.provider(memoryTypes, sensorTypes);
     }
 
-    private void refreshBrain(@NotNull ServerLevel level) {
+    private void refreshBrain(@Nonnull ServerLevel level) {
         Brain<Cat> brain = this.getBrain();
 
         brain.stopAll(level, this);

--- a/src/main/java/dev/breeze/settlements/entities/cats/sensors/CatOwnerSensor.java
+++ b/src/main/java/dev/breeze/settlements/entities/cats/sensors/CatOwnerSensor.java
@@ -1,0 +1,47 @@
+package dev.breeze.settlements.entities.cats.sensors;
+
+import dev.breeze.settlements.entities.cats.VillagerCat;
+import dev.breeze.settlements.entities.villagers.BaseVillager;
+import dev.breeze.settlements.utils.TimeUtil;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import net.minecraft.world.entity.animal.Cat;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Set;
+
+public class CatOwnerSensor extends Sensor<Cat> {
+
+    /**
+     * How often will the cat check its owner status
+     */
+    private static final int SENSE_COOLDOWN = TimeUtil.minutes(1);
+
+    public CatOwnerSensor() {
+        super(SENSE_COOLDOWN);
+    }
+
+    @Override
+    protected void doTick(@Nonnull ServerLevel world, @Nonnull Cat cat) {
+        // Type cast checking
+        if (!(cat instanceof VillagerCat villagerCat)) {
+            return;
+        }
+
+        BaseVillager owner = villagerCat.getOwner();
+        if (owner != null && owner.isAlive()) {
+            // Notify cat to refresh brain
+            villagerCat.onOwnerSensorTick();
+        }
+    }
+
+    @Override
+    @Nonnull
+    public Set<MemoryModuleType<?>> requires() {
+        // This sensor modifies no memories
+        return Collections.emptySet();
+    }
+
+}

--- a/src/main/java/dev/breeze/settlements/entities/cats/sensors/CatSensorType.java
+++ b/src/main/java/dev/breeze/settlements/entities/cats/sensors/CatSensorType.java
@@ -9,6 +9,7 @@ public class CatSensorType {
      */
     public static final String REGISTRY_KEY_OWNER = "settlements_cat_owner_sensor";
     public static SensorType<CatOwnerSensor> OWNER;
+
     /**
      * Sensor for scanning nearby items
      */

--- a/src/main/java/dev/breeze/settlements/entities/cats/sensors/CatSensorType.java
+++ b/src/main/java/dev/breeze/settlements/entities/cats/sensors/CatSensorType.java
@@ -5,6 +5,11 @@ import net.minecraft.world.entity.ai.sensing.SensorType;
 public class CatSensorType {
 
     /**
+     * Sensor for detecting owner
+     */
+    public static final String REGISTRY_KEY_OWNER = "settlements_cat_owner_sensor";
+    public static SensorType<CatOwnerSensor> OWNER;
+    /**
      * Sensor for scanning nearby items
      */
     public static final String REGISTRY_KEY_NEARBY_ITEMS = "settlements_cat_nearby_items_sensor";

--- a/src/main/java/dev/breeze/settlements/entities/wolves/VillagerWolf.java
+++ b/src/main/java/dev/breeze/settlements/entities/wolves/VillagerWolf.java
@@ -181,6 +181,7 @@ public class VillagerWolf extends Wolf {
      */
     @Override
     @Nonnull
+    @SuppressWarnings("unchecked")
     public Brain<Wolf> getBrain() {
         return (Brain<Wolf>) super.getBrain();
     }
@@ -239,7 +240,7 @@ public class VillagerWolf extends Wolf {
      */
     private void registerBrainGoals(Brain<Wolf> brain) {
         if (this.getOwner() == null || !this.getOwner().isAlive()) {
-            LogUtil.warning("Skipping registration of brain goals because owner is not available");
+            LogUtil.warning("Skipping registration of wolf brain goals because owner is not available");
             return;
         }
 
@@ -331,7 +332,7 @@ public class VillagerWolf extends Wolf {
             return;
         }
 
-        LogUtil.info("Owner detected, refreshing wolf brain goals!");
+        LogUtil.info("Owner detected, refreshing wolf brain goals");
         this.refreshBrain(this.level.getMinecraftWorld());
     }
 

--- a/src/main/java/dev/breeze/settlements/entities/wolves/sensors/WolfOwnerSensor.java
+++ b/src/main/java/dev/breeze/settlements/entities/wolves/sensors/WolfOwnerSensor.java
@@ -1,0 +1,47 @@
+package dev.breeze.settlements.entities.wolves.sensors;
+
+import dev.breeze.settlements.entities.villagers.BaseVillager;
+import dev.breeze.settlements.entities.wolves.VillagerWolf;
+import dev.breeze.settlements.utils.TimeUtil;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import net.minecraft.world.entity.animal.Wolf;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.Set;
+
+public class WolfOwnerSensor extends Sensor<Wolf> {
+
+    /**
+     * How often will the wolf check its owner status
+     */
+    private static final int SENSE_COOLDOWN = TimeUtil.minutes(1);
+
+    public WolfOwnerSensor() {
+        super(SENSE_COOLDOWN);
+    }
+
+    @Override
+    protected void doTick(@Nonnull ServerLevel world, @Nonnull Wolf wolf) {
+        // Type cast checking
+        if (!(wolf instanceof VillagerWolf villagerWolf)) {
+            return;
+        }
+
+        BaseVillager owner = villagerWolf.getOwner();
+        if (owner != null && owner.isAlive()) {
+            // Notify cat to refresh brain
+            villagerWolf.onOwnerSensorTick();
+        }
+    }
+
+    @Override
+    @Nonnull
+    public Set<MemoryModuleType<?>> requires() {
+        // This sensor modifies no memories
+        return Collections.emptySet();
+    }
+
+}

--- a/src/main/java/dev/breeze/settlements/entities/wolves/sensors/WolfSensorType.java
+++ b/src/main/java/dev/breeze/settlements/entities/wolves/sensors/WolfSensorType.java
@@ -5,6 +5,12 @@ import net.minecraft.world.entity.ai.sensing.SensorType;
 public class WolfSensorType {
 
     /**
+     * Sensor for detecting owner
+     */
+    public static final String REGISTRY_KEY_OWNER = "settlements_wolf_owner_sensor";
+    public static SensorType<WolfOwnerSensor> OWNER;
+
+    /**
      * Sensor for scanning nearby items
      */
     public static final String REGISTRY_KEY_NEARBY_ITEMS = "settlements_wolf_nearby_items_sensor";


### PR DESCRIPTION
**Bug: Pets brain goals does not register at non-spawn areas**
This is caused by the pets' owners are loaded after the pets themselves are loaded, which skips the brain behavior creation process. 

This pull request fixes this issue by introducing an "owner sensor" that will periodically (every 1 minute) scan for the owner. If the owner is detected for the first time, it will try to refresh the brain and register all behaviors. All subsequent detections will be ignored.

Another bug that this fixed along the way was that pets will attempt to schedule a task after upon plugin pre-load. This is not possible when the plugin load is set to POST_WORLD, causing all pets to disappear (fail to load).