### PR TITLE
Refactor of villager sensors and debug infrastructure

### DIFF
--- a/src/main/java/dev/breeze/settlements/Main.java
+++ b/src/main/java/dev/breeze/settlements/Main.java
@@ -6,6 +6,7 @@ import dev.breeze.settlements.entities.EntityModuleController;
 import dev.breeze.settlements.guis.GuiModuleController;
 import dev.breeze.settlements.test.TestModuleController;
 import dev.breeze.settlements.utils.BaseModuleController;
+import dev.breeze.settlements.utils.DebugUtil;
 import dev.breeze.settlements.utils.LogUtil;
 import lombok.Getter;
 import lombok.Setter;
@@ -48,7 +49,7 @@ public final class Main extends JavaPlugin {
             f.mkdir();
 
         // Preload modules
-        LogUtil.info("Preloading modules...");
+        DebugUtil.log("Preloading modules...");
         for (BaseModuleController bmc : this.moduleControllers) {
             if (!bmc.performPreload(this)) {
                 this.disableSelf("Failed to preload module '%s'!", bmc.getClass().getName());
@@ -63,13 +64,13 @@ public final class Main extends JavaPlugin {
     public void onEnable() {
         // Abandon loading if disabled
         if (this.disablePlugin) {
-            LogUtil.info("Disabling plugin due to failed initialization...");
+            LogUtil.severe("Disabling plugin due to failed initialization...");
             this.getServer().getPluginManager().disablePlugin(this);
             return;
         }
 
         // Load modules
-        LogUtil.info("Loading modules...");
+        DebugUtil.log("Loading modules...");
         PluginManager pm = this.getServer().getPluginManager();
         for (BaseModuleController bmc : this.moduleControllers) {
             if (!bmc.performLoad(this, pm)) {

--- a/src/main/java/dev/breeze/settlements/debug/DebugCommandHandler.java
+++ b/src/main/java/dev/breeze/settlements/debug/DebugCommandHandler.java
@@ -1,5 +1,6 @@
 package dev.breeze.settlements.debug;
 
+import dev.breeze.settlements.utils.DebugUtil;
 import dev.breeze.settlements.utils.MessageUtil;
 import dev.breeze.settlements.utils.SoundUtil;
 import dev.breeze.settlements.utils.itemstack.ItemStackBuilder;
@@ -23,27 +24,28 @@ public class DebugCommandHandler implements TabExecutor {
     public boolean onCommand(@Nonnull CommandSender sender, @Nonnull Command command, @Nonnull String label, String[] args) {
         if (!(sender instanceof Player p)) {
             // Console command
-            MessageUtil.sendMessage(sender, "Go away evil console!!!");
+            MessageUtil.sendMessageWithPrefix(sender, "Go away evil console!!!");
             return true;
         }
 
-        if (!p.isOp()) {
-            // Admin-only command
-            MessageUtil.sendMessage(sender, "You must be an operator to use this command!");
+        // TODO: refactor permissions
+        // Check if the player has permission to execute the command
+        if (!p.hasPermission("settlements.admin")) {
+            MessageUtil.sendMessageWithPrefix(sender, "&cYou lack the required permission to use this command!");
         }
 
         String subCommand = args.length > 0 ? args[0].toLowerCase() : "help";
         switch (subCommand) {
+            case "toggle" -> toggleDebug(p);
             case "tool" -> debugTool(p);
             default -> {
                 // Help or other
                 // TODO: send help message
-                MessageUtil.sendMessage(p, "&cInvalid debug format!");
+                MessageUtil.sendMessageWithPrefix(p, "&cInvalid debug format!");
                 return true;
             }
         }
 
-        MessageUtil.sendMessage(p, "Test execution complete!");
         return true;
     }
 
@@ -55,10 +57,16 @@ public class DebugCommandHandler implements TabExecutor {
         }
 
         if (args.length == 1) {
+            tabComplete.add("toggle");
             tabComplete.add("tool");
             tabComplete.add("help");
         }
         return tabComplete.stream().filter(completion -> completion.toLowerCase().contains(args[args.length - 1].toLowerCase())).toList();
+    }
+
+    public static void toggleDebug(Player p) {
+        DebugUtil.toggleDebugging();
+        MessageUtil.sendMessageWithPrefix(p, "%s debugging mode", DebugUtil.isDebuggingEnabled() ? "&aEnabled" : "&cDisabled");
     }
 
     private static void debugTool(Player p) {
@@ -69,7 +77,7 @@ public class DebugCommandHandler implements TabExecutor {
                 .build();
         p.getInventory().addItem(debugStick);
         SoundUtil.playSound(p, Sound.ENTITY_ITEM_PICKUP, 1);
-        MessageUtil.sendMessage(p, "&eYou've obtained a debug tool");
+        MessageUtil.sendMessageWithPrefix(p, "&eYou've obtained a debug tool");
     }
 
 }

--- a/src/main/java/dev/breeze/settlements/debug/DebugModuleController.java
+++ b/src/main/java/dev/breeze/settlements/debug/DebugModuleController.java
@@ -21,7 +21,7 @@ public class DebugModuleController extends BaseModuleController {
         plugin.getCommand("settlements_debug").setExecutor(new DebugCommandHandler());
 
         // Register events
-        pm.registerEvents(new MemoryEvent(), plugin);
+        pm.registerEvents(new DebugStickEvent(), plugin);
 
         // Inventory events
         pm.registerEvents(new VillagerDebugMainGui(), plugin);

--- a/src/main/java/dev/breeze/settlements/debug/DebugModuleController.java
+++ b/src/main/java/dev/breeze/settlements/debug/DebugModuleController.java
@@ -3,6 +3,7 @@ package dev.breeze.settlements.debug;
 import dev.breeze.settlements.debug.guis.villager.VillagerDebugBehaviorGui;
 import dev.breeze.settlements.debug.guis.villager.VillagerDebugMainGui;
 import dev.breeze.settlements.debug.guis.villager.VillagerDebugMemoryGui;
+import dev.breeze.settlements.debug.guis.villager.VillagerDebugSensorGui;
 import dev.breeze.settlements.utils.BaseModuleController;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -26,6 +27,7 @@ public class DebugModuleController extends BaseModuleController {
         pm.registerEvents(new VillagerDebugMainGui(), plugin);
         pm.registerEvents(new VillagerDebugBehaviorGui(), plugin);
         pm.registerEvents(new VillagerDebugMemoryGui(), plugin);
+        pm.registerEvents(new VillagerDebugSensorGui(), plugin);
         return true;
     }
 

--- a/src/main/java/dev/breeze/settlements/debug/DebugStickEvent.java
+++ b/src/main/java/dev/breeze/settlements/debug/DebugStickEvent.java
@@ -8,13 +8,16 @@ import dev.breeze.settlements.entities.wolves.VillagerWolf;
 import dev.breeze.settlements.entities.wolves.memories.WolfMemoryType;
 import dev.breeze.settlements.entities.wolves.sensors.WolfFenceAreaSensor;
 import dev.breeze.settlements.utils.MessageUtil;
+import dev.breeze.settlements.utils.RayTraceUtil;
 import dev.breeze.settlements.utils.TimeUtil;
 import dev.breeze.settlements.utils.particle.ParticlePreset;
 import dev.breeze.settlements.utils.particle.ParticleUtil;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.memory.ExpirableValue;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
@@ -22,27 +25,85 @@ import net.minecraft.world.entity.animal.Cat;
 import net.minecraft.world.entity.animal.Wolf;
 import org.bukkit.*;
 import org.bukkit.craftbukkit.v1_19_R2.entity.CraftEntity;
+import org.bukkit.craftbukkit.v1_19_R2.entity.CraftPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractAtEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 
+import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Optional;
 
-public class MemoryEvent implements Listener {
+public class DebugStickEvent implements Listener {
 
+    /**
+     * Event handler for right-clicking with the debug stick
+     */
     @EventHandler
     public void onClickEntity(PlayerInteractAtEntityEvent event) {
         Player player = event.getPlayer();
-        World world = player.getWorld();
         ItemStack item = player.getInventory().getItem(event.getHand());
-
-        if (item.getType() != Material.DEBUG_STICK || !item.hasItemMeta())
+        if (item.getType() != Material.DEBUG_STICK || !item.hasItemMeta()) {
             return;
-        Entity entity = ((CraftEntity) event.getRightClicked()).getHandle();
+        }
+
         event.setCancelled(true);
+        debug(player, ((CraftEntity) event.getRightClicked()).getHandle());
+    }
+
+
+    /**
+     * Event handler for right-clicking air with debug stick (ray trace)
+     */
+    @EventHandler
+    public void onClickAir(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_AIR) {
+            return;
+        }
+
+        ItemStack item = event.getItem();
+        if (item == null || item.getType() != Material.DEBUG_STICK || !item.hasItemMeta()) {
+            return;
+        }
+
+        event.setCancelled(true);
+
+        Player player = event.getPlayer();
+
+        // Ray trace the entity
+        int maxRayTraceDistance = 60;
+        ServerPlayer serverPlayer = ((CraftPlayer) player).getHandle();
+        RayTraceUtil.RayTraceResult rayTraceResult = RayTraceUtil.getTargetEntity(serverPlayer, maxRayTraceDistance);
+
+        // We found no targets
+        if (rayTraceResult == null) {
+            // Display not found particles
+            Location target = player.getEyeLocation().add(player.getLocation().getDirection().normalize().multiply(maxRayTraceDistance));
+            ParticlePreset.displayLinePrivate(player, player.getEyeLocation(), target, maxRayTraceDistance, Particle.END_ROD, 1, 0, 0, 0, 0);
+            ParticleUtil.playerParticle(player, target, Particle.END_ROD, 15, 0.1, 0.1, 0.1, 1);
+            return;
+        }
+
+        // Display particles to the entity
+        Entity entity = rayTraceResult.entity();
+        Location target = new Location(player.getWorld(), entity.getX(), entity.getY(), entity.getZ());
+        ParticlePreset.displayLinePrivate(player, player.getEyeLocation(), target, 15, Particle.END_ROD, 1, 0, 0, 0, 0);
+
+        // Debug
+        debug(player, entity);
+    }
+
+    private void debug(@Nonnull Player player, @Nonnull Entity entity) {
+        World world = player.getWorld();
+        Location location = new Location(world, entity.getX(), entity.getY(), entity.getZ());
+
+        if (entity instanceof LivingEntity livingEntity) {
+            livingEntity.addEffect(new MobEffectInstance(MobEffects.GLOWING, TimeUtil.seconds(1), 0, false, false));
+        }
 
         if (entity instanceof VillagerWolf wolf) {
             Brain<Wolf> brain = wolf.getBrain();
@@ -57,8 +118,8 @@ public class MemoryEvent implements Listener {
                 // Display fence positions
                 WolfFenceAreaSensor.FenceArea fenceArea = brain.getMemory(WolfMemoryType.NEAREST_FENCE_AREA).get();
                 for (BlockPos pos : fenceArea.getFences()) {
-                    Location location = new Location(world, pos.getX() + 0.5, pos.getY() + 1, pos.getZ() + 0.5);
-                    ParticleUtil.globalParticle(location, Particle.SPELL_WITCH, 1, 0, 0, 0, 0);
+                    Location fence = new Location(world, pos.getX() + 0.5, pos.getY() + 1, pos.getZ() + 0.5);
+                    ParticleUtil.globalParticle(fence, Particle.SPELL_WITCH, 1, 0, 0, 0, 0);
                 }
 
                 // Display gate position
@@ -67,18 +128,15 @@ public class MemoryEvent implements Listener {
                 ParticleUtil.globalParticle(gateLoc, Particle.VILLAGER_HAPPY, 20, 0.5, 0.5, 0.5, 0);
 
                 // Draw line from the wolf to the gate
-                ParticlePreset.displayLine(event.getRightClicked().getLocation(), gateLoc, 20, Particle.END_ROD, 1, 0, 0, 0, 0);
+                ParticlePreset.displayLine(location, gateLoc, 20, Particle.END_ROD, 1, 0, 0, 0, 0);
             }
 
             // Draw line to owner
             if (wolf.getOwner() != null && wolf.getOwner().isAlive()) {
-                ParticlePreset.displayLine(event.getRightClicked().getLocation(), wolf.getOwner().getBukkitEntity().getLocation(),
-                        20, Particle.END_ROD, 1, 0, 0, 0, 0);
+                ParticlePreset.displayLine(location, wolf.getOwner().getBukkitEntity().getLocation(), 20, Particle.END_ROD, 1, 0, 0, 0, 0);
                 wolf.getOwner().addEffect(new MobEffectInstance(MobEffects.GLOWING, TimeUtil.seconds(5), 0, false, false));
             }
         } else if (entity instanceof VillagerCat cat) {
-            event.setCancelled(true);
-
             Brain<Cat> brain = cat.getBrain();
             Map<MemoryModuleType<?>, Optional<? extends ExpirableValue<?>>> memories = brain.getMemories();
             MessageUtil.sendMessageWithoutPrefix(player, "&bMemories of cat:");
@@ -88,8 +146,7 @@ public class MemoryEvent implements Listener {
 
             // Draw line to owner
             if (cat.getOwner() != null && cat.getOwner().isAlive()) {
-                ParticlePreset.displayLine(event.getRightClicked().getLocation(), cat.getOwner().getBukkitEntity().getLocation(),
-                        20, Particle.END_ROD, 1, 0, 0, 0, 0);
+                ParticlePreset.displayLine(location, cat.getOwner().getBukkitEntity().getLocation(), 20, Particle.END_ROD, 1, 0, 0, 0, 0);
                 cat.getOwner().addEffect(new MobEffectInstance(MobEffects.GLOWING, TimeUtil.seconds(5), 0, false, false));
             }
         } else if (entity instanceof BaseVillager villager) {
@@ -98,7 +155,6 @@ public class MemoryEvent implements Listener {
                 player.openInventory(VillagerDebugMainGui.getViewableInventory(player, villager).getBukkitInventory());
             }, TimeUtil.ticks(5));
         }
-
     }
 
 }

--- a/src/main/java/dev/breeze/settlements/debug/MemoryEvent.java
+++ b/src/main/java/dev/breeze/settlements/debug/MemoryEvent.java
@@ -47,10 +47,10 @@ public class MemoryEvent implements Listener {
         if (entity instanceof VillagerWolf wolf) {
             Brain<Wolf> brain = wolf.getBrain();
             Map<MemoryModuleType<?>, Optional<? extends ExpirableValue<?>>> memories = brain.getMemories();
-            MessageUtil.sendMessage(player, "&bMemories of wolf:");
+            MessageUtil.sendMessageWithoutPrefix(player, "&bMemories of wolf:");
             for (Map.Entry<MemoryModuleType<?>, Optional<? extends ExpirableValue<?>>> entry : memories.entrySet())
-                MessageUtil.sendMessage(player, "&b - %s : %s", entry.getKey().toString(), entry.getValue().toString());
-            MessageUtil.sendMessage(player, "&b - Owned by: %s (%s)", wolf.getOwner(), wolf.getOwnerUUID());
+                MessageUtil.sendMessageWithoutPrefix(player, "&b - %s : %s", entry.getKey().toString(), entry.getValue().toString());
+            MessageUtil.sendMessageWithoutPrefix(player, "&b - Owned by: %s (%s)", wolf.getOwner(), wolf.getOwnerUUID());
 
             // Display fence area visually
             if (brain.hasMemoryValue(WolfMemoryType.NEAREST_FENCE_AREA)) {
@@ -81,10 +81,10 @@ public class MemoryEvent implements Listener {
 
             Brain<Cat> brain = cat.getBrain();
             Map<MemoryModuleType<?>, Optional<? extends ExpirableValue<?>>> memories = brain.getMemories();
-            MessageUtil.sendMessage(player, "&bMemories of cat:");
+            MessageUtil.sendMessageWithoutPrefix(player, "&bMemories of cat:");
             for (Map.Entry<MemoryModuleType<?>, Optional<? extends ExpirableValue<?>>> entry : memories.entrySet())
-                MessageUtil.sendMessage(player, "&b - %s : %s", entry.getKey().toString(), entry.getValue().toString());
-            MessageUtil.sendMessage(player, "&b - Owned by: %s (%s)", cat.getOwner(), cat.getOwnerUUID());
+                MessageUtil.sendMessageWithoutPrefix(player, "&b - %s : %s", entry.getKey().toString(), entry.getValue().toString());
+            MessageUtil.sendMessageWithoutPrefix(player, "&b - Owned by: %s (%s)", cat.getOwner(), cat.getOwnerUUID());
 
             // Draw line to owner
             if (cat.getOwner() != null && cat.getOwner().isAlive()) {

--- a/src/main/java/dev/breeze/settlements/debug/guis/villager/VillagerDebugMainGui.java
+++ b/src/main/java/dev/breeze/settlements/debug/guis/villager/VillagerDebugMainGui.java
@@ -28,8 +28,9 @@ public class VillagerDebugMainGui implements Listener {
     private static final String INVENTORY_IDENTIFIER = "debug_villager";
 
     // Register slots for all clickable slots
-    private static final int SLOT_BEHAVIORS = InventoryUtil.toIndex(2, 6);
-    private static final int SLOT_MEMORIES = InventoryUtil.toIndex(2, 7);
+    private static final int SLOT_BEHAVIORS = InventoryUtil.toIndex(2, 5);
+    private static final int SLOT_MEMORIES = InventoryUtil.toIndex(2, 6);
+    private static final int SLOT_SENSORS = InventoryUtil.toIndex(2, 7);
     private static final int SLOT_INVENTORY = InventoryUtil.toIndex(2, 8);
     private static final int SLOT_CLOSE_MENU = InventoryUtil.rowMiddleIndex(3);
 
@@ -55,14 +56,8 @@ public class VillagerDebugMainGui implements Listener {
                 .setLore("%s &7(%d)".formatted(ReputationLevels.getTitle(reputation), reputation))
                 .build());
 
-        // Hunger level (no listener needed)
-        bukkitInventory.setItem(InventoryUtil.toIndex(2, 4), new ItemStackBuilder(Material.APPLE)
-                .setDisplayName("&e&lHunger Level")
-                .setLore("&6Peckish (example, WIP)")
-                .build());
-
         // Scheduled activity (no listener needed)
-        bukkitInventory.setItem(InventoryUtil.toIndex(2, 5), new ItemStackBuilder(Material.CLOCK)
+        bukkitInventory.setItem(InventoryUtil.toIndex(2, 4), new ItemStackBuilder(Material.CLOCK)
                 .setDisplayName("&e&lScheduled Activity")
                 .setLore(getVillagerActivityStrings(villager))
                 .build());
@@ -77,6 +72,12 @@ public class VillagerDebugMainGui implements Listener {
         bukkitInventory.setItem(SLOT_MEMORIES, new ItemStackBuilder(Material.WRITABLE_BOOK)
                 .setDisplayName("&e&lMemories")
                 .setLore("&7Click to view villager's memories")
+                .build());
+
+        // Sensors
+        bukkitInventory.setItem(SLOT_SENSORS, new ItemStackBuilder(Material.SCULK_SENSOR)
+                .setDisplayName("&e&lSensors")
+                .setLore("&7Click to view villager's sensors")
                 .build());
 
         // Inventory
@@ -109,6 +110,10 @@ public class VillagerDebugMainGui implements Listener {
         } else if (slot == SLOT_MEMORIES) {
             // Show villager's memories
             VillagerDebugMemoryGui.getViewableInventory(player, holder.getVillager()).showToPlayer(player);
+            SoundPresets.inventoryClickEnter(player);
+        } else if (slot == SLOT_SENSORS) {
+            // Show villager's sensors
+            VillagerDebugSensorGui.getViewableInventory(player, holder.getVillager()).showToPlayer(player);
             SoundPresets.inventoryClickEnter(player);
         } else if (slot == SLOT_INVENTORY) {
             // Show villager's inventory to the player, allowing edits

--- a/src/main/java/dev/breeze/settlements/debug/guis/villager/VillagerDebugSensorGui.java
+++ b/src/main/java/dev/breeze/settlements/debug/guis/villager/VillagerDebugSensorGui.java
@@ -1,0 +1,68 @@
+package dev.breeze.settlements.debug.guis.villager;
+
+import dev.breeze.settlements.entities.villagers.BaseVillager;
+import dev.breeze.settlements.entities.villagers.sensors.BaseVillagerSensor;
+import dev.breeze.settlements.entities.villagers.sensors.VillagerSensor;
+import dev.breeze.settlements.entities.villagers.sensors.VillagerSensorType;
+import dev.breeze.settlements.guis.CustomInventory;
+import dev.breeze.settlements.utils.InventoryUtil;
+import dev.breeze.settlements.utils.SoundPresets;
+import dev.breeze.settlements.utils.itemstack.ItemPreset;
+import dev.breeze.settlements.utils.itemstack.ItemStackBuilder;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+import javax.annotation.Nonnull;
+
+public class VillagerDebugSensorGui implements Listener {
+
+    private static final String INVENTORY_IDENTIFIER = "debug_villager_sensor";
+
+    // Register slots for all clickable slots
+    private static final int SLOT_PREVIOUS_MENU = InventoryUtil.rowMiddleIndex(6);
+
+    @Nonnull
+    public static CustomInventory getViewableInventory(Player player, BaseVillager villager) {
+        CustomInventory inventory = new CustomInventory(6, "&9Debug - Villager Sensors", new VillagerDebugInventoryHolder(INVENTORY_IDENTIFIER, villager));
+        Inventory bukkitInventory = inventory.getBukkitInventory();
+
+        // Create inventory border (no listener needed)
+        InventoryUtil.boarderInventory(bukkitInventory, ItemPreset.INVENTORY_BLACK_GLASS_PANE.getBuilder().build());
+
+        // Entity type item (no listener needed)
+        bukkitInventory.setItem(InventoryUtil.rowMiddleIndex(1), new ItemStackBuilder(Material.SCULK_SENSOR).setDisplayName("&a&lVillager Sensors").build());
+
+        // Add memory items (no click events)
+        for (VillagerSensor<? extends BaseVillagerSensor> sensor : VillagerSensorType.ALL_SENSORS) {
+            int index = bukkitInventory.firstEmpty();
+            bukkitInventory.setItem(index, sensor.getGuiItem());
+        }
+
+        // Exit button
+        bukkitInventory.setItem(SLOT_PREVIOUS_MENU, ItemPreset.INVENTORY_BACK_BUTTON.getBuilder().setDisplayName("&cBack").build());
+
+        return inventory;
+    }
+
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent event) {
+        // Check event validity
+        if (!(event.getWhoClicked() instanceof Player player) || !(event.getInventory().getHolder() instanceof VillagerDebugInventoryHolder holder) || !holder.idMatch(INVENTORY_IDENTIFIER)) {
+            return;
+        }
+
+        // Cancel event
+        event.setCancelled(true);
+
+        int slot = event.getSlot();
+        if (slot == SLOT_PREVIOUS_MENU) {
+            player.openInventory(VillagerDebugMainGui.getViewableInventory(player, holder.getVillager()).getBukkitInventory());
+            SoundPresets.inventoryClickExit(player);
+        }
+    }
+
+}

--- a/src/main/java/dev/breeze/settlements/entities/EntityModuleController.java
+++ b/src/main/java/dev/breeze/settlements/entities/EntityModuleController.java
@@ -18,6 +18,7 @@ import dev.breeze.settlements.entities.wolves.VillagerWolf;
 import dev.breeze.settlements.entities.wolves.memories.WolfMemoryType;
 import dev.breeze.settlements.entities.wolves.sensors.*;
 import dev.breeze.settlements.utils.BaseModuleController;
+import dev.breeze.settlements.utils.DebugUtil;
 import dev.breeze.settlements.utils.LogUtil;
 import net.minecraft.core.MappedRegistry;
 import net.minecraft.core.Registry;
@@ -96,19 +97,22 @@ public class EntityModuleController extends BaseModuleController {
     @SuppressWarnings("JavaReflectionMemberAccess")
     private void registerEntities(Map<String, EntityType.Builder<Entity>> entityTypeMap) throws IllegalAccessException, InvocationTargetException,
             NoSuchMethodException, NoSuchFieldException {
+        LogUtil.info("Registering custom entities, it's normal if you see messages like 'No data fixer registered for XXX'");
+        DebugUtil.log("Attempting to register custom entities...");
+
         // Get entity type registry
         DedicatedServer dedicatedServer = ((CraftServer) Bukkit.getServer()).getServer();
         WritableRegistry<EntityType<?>> entityTypeRegistry =
                 (WritableRegistry<EntityType<?>>) dedicatedServer.registryAccess().registryOrThrow(Registries.ENTITY_TYPE);
 
         // Unfreeze registry
-        LogUtil.info("Unfreezing entity type registry (1/2)...");
+        DebugUtil.log("> Unfreezing entity type registry (1/2)...");
         // l = private boolean frozen
         Field frozen = MappedRegistry.class.getDeclaredField("l");
         frozen.setAccessible(true);
         frozen.set(entityTypeRegistry, false);
 
-        LogUtil.info("Unfreezing entity type registry (2/2)...");
+        DebugUtil.log("> Unfreezing entity type registry (2/2)...");
         // m = private Map<T, Holder.Reference<T>> unregisteredIntrusiveHolders;
         Field unregisteredHolderMap = MappedRegistry.class.getDeclaredField("m");
         unregisteredHolderMap.setAccessible(true);
@@ -122,12 +126,15 @@ public class EntityModuleController extends BaseModuleController {
         // Build & register entities
         for (Map.Entry<String, EntityType.Builder<Entity>> entry : entityTypeMap.entrySet()) {
             register.invoke(null, entry.getKey(), entry.getValue());
+            DebugUtil.log("> Registered entity '%s' successfully!", entry.getKey());
         }
 
         // Re-freeze registry
-        LogUtil.info("Re-freezing entity type registry...");
+        DebugUtil.log("> Re-freezing entity type registry...");
         BuiltInRegistries.ENTITY_TYPE.freeze();
         unregisteredHolderMap.set(BuiltInRegistries.ENTITY_TYPE, null);
+
+        DebugUtil.log("Custom entities registered successfully!");
     }
 
     /**
@@ -136,13 +143,15 @@ public class EntityModuleController extends BaseModuleController {
      */
     @SuppressWarnings("JavaReflectionMemberAccess")
     private void registerMemories() throws IllegalAccessException, NoSuchMethodException, NoSuchFieldException {
+        DebugUtil.log("Attempting to register custom memories...");
+
         // Get memory module type registry
         DedicatedServer dedicatedServer = ((CraftServer) Bukkit.getServer()).getServer();
         WritableRegistry<MemoryModuleType<?>> registry =
                 (WritableRegistry<MemoryModuleType<?>>) dedicatedServer.registryAccess().registryOrThrow(Registries.MEMORY_MODULE_TYPE);
 
         // Unfreeze registry
-        LogUtil.info("Unfreezing memory module type registry...");
+        DebugUtil.log("> Unfreezing memory module type registry...");
         // l = private boolean frozen
         Field frozen = MappedRegistry.class.getDeclaredField("l");
         frozen.setAccessible(true);
@@ -152,11 +161,13 @@ public class EntityModuleController extends BaseModuleController {
          * Build & register memories
          */
         // Villager memories
+        DebugUtil.log("> Registering custom villager memories...");
         for (VillagerMemory<?> memory : VillagerMemoryType.ALL_MEMORIES) {
             memory.setMemoryModuleType(registerMemory(memory.getIdentifier(), null));
         }
 
         // Wolf memories
+        DebugUtil.log("> Registering custom wolf memories...");
         WolfMemoryType.NEARBY_ITEMS = registerMemory(WolfMemoryType.REGISTRY_KEY_NEARBY_ITEMS, null);
         WolfMemoryType.NEARBY_SNIFFABLE_ENTITIES = registerMemory(WolfMemoryType.REGISTRY_KEY_SNIFFABLE_ENTITIES, null);
         WolfMemoryType.RECENTLY_SNIFFED_ENTITIES = registerMemory(WolfMemoryType.REGISTRY_KEY_RECENTLY_SNIFFED_ENTITIES, null);
@@ -164,11 +175,14 @@ public class EntityModuleController extends BaseModuleController {
         WolfMemoryType.NEARBY_SHEEP = registerMemory(WolfMemoryType.REGISTRY_KEY_NEARBY_SHEEP, null);
 
         // Cat memories
+        DebugUtil.log("> Registering custom cat memories...");
         CatMemoryType.NEARBY_ITEMS = registerMemory(CatMemoryType.REGISTRY_KEY_NEARBY_ITEMS, null);
 
         // Re-freeze registry
-        LogUtil.info("Re-freezing memory module type registry...");
+        DebugUtil.log("> Re-freezing memory module type registry...");
         BuiltInRegistries.MEMORY_MODULE_TYPE.freeze();
+
+        DebugUtil.log("Custom memories registered successfully!");
     }
 
     private <U> MemoryModuleType<U> registerMemory(@Nonnull String id, @Nullable Codec<U> codec) {
@@ -185,12 +199,14 @@ public class EntityModuleController extends BaseModuleController {
     @SuppressWarnings("JavaReflectionMemberAccess")
     private void registerSensors() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException, NoSuchFieldException,
             InstantiationException {
+        DebugUtil.log("Attempting to register custom sensors...");
+
         // Get sensor type registry
         DedicatedServer dedicatedServer = ((CraftServer) Bukkit.getServer()).getServer();
         WritableRegistry<SensorType<?>> registry = (WritableRegistry<SensorType<?>>) dedicatedServer.registryAccess().registryOrThrow(Registries.SENSOR_TYPE);
 
         // Unfreeze registry
-        LogUtil.info("Unfreezing sensor type registry...");
+        DebugUtil.log("> Unfreezing sensor type registry...");
         // l = private boolean frozen
         Field frozen = MappedRegistry.class.getDeclaredField("l");
         frozen.setAccessible(true);
@@ -200,11 +216,13 @@ public class EntityModuleController extends BaseModuleController {
          * Build & register sensors
          */
         // Villager sensors
+        DebugUtil.log("> Registering custom villager sensors...");
         for (VillagerSensor<? extends BaseVillagerSensor> sensor : VillagerSensorType.ALL_SENSORS) {
             sensor.setSensorType(registerSensor(sensor.getIdentifier(), sensor.getSensorSupplier()));
         }
 
         // Wolf sensors
+        DebugUtil.log("> Registering custom wolf sensors...");
         WolfSensorType.OWNER = registerSensor(WolfSensorType.REGISTRY_KEY_OWNER, WolfOwnerSensor::new);
         WolfSensorType.NEARBY_ITEMS = registerSensor(WolfSensorType.REGISTRY_KEY_NEARBY_ITEMS, WolfNearbyItemsSensor::new);
         WolfSensorType.NEARBY_SNIFFABLE_ENTITIES = registerSensor(WolfSensorType.REGISTRY_KEY_NEARBY_SNIFFABLE_ENTITIES, WolfSniffableEntitiesSensor::new);
@@ -212,12 +230,15 @@ public class EntityModuleController extends BaseModuleController {
         WolfSensorType.NEARBY_SHEEP = registerSensor(WolfSensorType.REGISTRY_KEY_NEARBY_SHEEP, WolfNearbySheepSensor::new);
 
         // Cat sensors
+        DebugUtil.log("> Registering custom sensor memories...");
         CatSensorType.OWNER = registerSensor(CatSensorType.REGISTRY_KEY_OWNER, CatOwnerSensor::new);
         CatSensorType.NEARBY_ITEMS = registerSensor(CatSensorType.REGISTRY_KEY_NEARBY_ITEMS, CatNearbyItemsSensor::new);
 
         // Re-freeze registry
-        LogUtil.info("Re-freezing sensor type registry...");
+        DebugUtil.log("> Re-freezing sensor type registry...");
         BuiltInRegistries.SENSOR_TYPE.freeze();
+
+        DebugUtil.log("Custom sensors registered successfully!");
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/main/java/dev/breeze/settlements/entities/EntityModuleController.java
+++ b/src/main/java/dev/breeze/settlements/entities/EntityModuleController.java
@@ -11,7 +11,9 @@ import dev.breeze.settlements.entities.villagers.events.VillagerRestockEvent;
 import dev.breeze.settlements.entities.villagers.inventory.VillagerInventoryEditEvents;
 import dev.breeze.settlements.entities.villagers.memories.VillagerMemory;
 import dev.breeze.settlements.entities.villagers.memories.VillagerMemoryType;
-import dev.breeze.settlements.entities.villagers.sensors.*;
+import dev.breeze.settlements.entities.villagers.sensors.BaseVillagerSensor;
+import dev.breeze.settlements.entities.villagers.sensors.VillagerSensor;
+import dev.breeze.settlements.entities.villagers.sensors.VillagerSensorType;
 import dev.breeze.settlements.entities.wolves.VillagerWolf;
 import dev.breeze.settlements.entities.wolves.memories.WolfMemoryType;
 import dev.breeze.settlements.entities.wolves.sensors.*;
@@ -198,13 +200,9 @@ public class EntityModuleController extends BaseModuleController {
          * Build & register sensors
          */
         // Villager sensors
-        VillagerSensorType.NEAREST_WATER_AREA = registerSensor(VillagerSensorType.REGISTRY_KEY_NEAREST_WATER_AREA, VillagerNearbyWaterAreaSensor::new);
-        VillagerSensorType.IS_MEAL_TIME = registerSensor(VillagerSensorType.REGISTRY_KEY_IS_MEAL_TIME, VillagerMealTimeSensor::new);
-        VillagerSensorType.NEAREST_ENCHANTING_TABLE = registerSensor(VillagerSensorType.REGISTRY_KEY_NEAREST_ENCHANTING_TABLE,
-                VillagerNearbyEnchantingTableSensor::new);
-        VillagerSensorType.NEAREST_HARVESTABLE_SUGARCANE = registerSensor(VillagerSensorType.REGISTRY_KEY_NEAREST_HARVESTABLE_SUGARCANE,
-                VillagerNearbyHarvestableSugarcaneSensor::new);
-        VillagerSensorType.CURRENT_HABITAT = registerSensor(VillagerSensorType.REGISTRY_KEY_CURRENT_HABITAT, VillagerHabitatSensor::new);
+        for (VillagerSensor<? extends BaseVillagerSensor> sensor : VillagerSensorType.ALL_SENSORS) {
+            sensor.setSensorType(registerSensor(sensor.getIdentifier(), sensor.getSensorSupplier()));
+        }
 
         // Wolf sensors
         WolfSensorType.OWNER = registerSensor(WolfSensorType.REGISTRY_KEY_OWNER, WolfOwnerSensor::new);
@@ -223,7 +221,7 @@ public class EntityModuleController extends BaseModuleController {
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    private <U extends Sensor<?>> SensorType<U> registerSensor(@Nonnull String id, @Nonnull Supplier<U> factory) throws NoSuchMethodException,
+    private <U extends Sensor<?>> SensorType<U> registerSensor(@Nonnull String id, @Nonnull Supplier<?> factory) throws NoSuchMethodException,
             InvocationTargetException, InstantiationException, IllegalAccessException {
         Constructor<SensorType> constructor = SensorType.class.getDeclaredConstructor(Supplier.class);
         constructor.setAccessible(true);

--- a/src/main/java/dev/breeze/settlements/entities/cats/VillagerCat.java
+++ b/src/main/java/dev/breeze/settlements/entities/cats/VillagerCat.java
@@ -14,7 +14,7 @@ import dev.breeze.settlements.entities.cats.goals.CatSitWhenOrderedToGoal;
 import dev.breeze.settlements.entities.cats.memories.CatMemoryType;
 import dev.breeze.settlements.entities.cats.sensors.CatSensorType;
 import dev.breeze.settlements.entities.villagers.BaseVillager;
-import dev.breeze.settlements.utils.LogUtil;
+import dev.breeze.settlements.utils.DebugUtil;
 import lombok.Getter;
 import lombok.Setter;
 import net.minecraft.nbt.CompoundTag;
@@ -125,14 +125,14 @@ public class VillagerCat extends Cat {
     @Override
     public void load(@Nonnull CompoundTag nbt) {
         super.load(nbt);
-        LogUtil.info("Loading custom cat...");
+        DebugUtil.log("Loading custom cat (%s)", this.getUUID().toString());
 
         // TODO: restore any NBT data if needed
     }
 
     @Override
     public boolean save(@Nonnull CompoundTag nbt) {
-        LogUtil.info("Saving custom cat");
+        DebugUtil.log("Saving custom cat (%s)", this.getUUID().toString());
         return super.save(nbt);
     }
 
@@ -222,11 +222,11 @@ public class VillagerCat extends Cat {
      */
     private void registerBrainGoals(Brain<Cat> brain) {
         if (this.getOwner() == null || !this.getOwner().isAlive()) {
-            LogUtil.warning("Skipping registration of cat brain goals because owner is not available");
+            DebugUtil.log("Skipping initialization of cat (%s) brain because owner is not available", this.getUUID().toString());
             return;
         }
 
-        LogUtil.info("Registering cat brain goals");
+        DebugUtil.log("Initializing brain for cat (%s)", this.getUUID().toString());
 
         // Set activity schedule
         // - cat is active from dusk (13000) to dawn (22000) & when villagers are working (2000-9000)
@@ -305,8 +305,24 @@ public class VillagerCat extends Cat {
             return;
         }
 
-        LogUtil.info("Owner detected, refreshing cat brain goals");
+        // Check base condition
+        if (this.getOwnerUUID() == null) {
+            return;
+        }
+
+        DebugUtil.log("Owner (%s) detected, refreshing cat (%s) brain goals", this.getOwnerUUID().toString(), this.getUUID().toString());
         this.refreshBrain(this.level.getMinecraftWorld());
+    }
+
+    /**
+     * Returns a short description of this villager cat, primarily used in hover messages
+     */
+    public List<String> getHoverDescription() {
+        return List.of(
+                "Entity type: %s".formatted(ENTITY_TYPE),
+                "Owned by: %s".formatted(this.getOwner() == null ? "N/A" : this.getOwnerUUID().toString()),
+                "UUID: %s".formatted(this.getStringUUID())
+        );
     }
 
 }

--- a/src/main/java/dev/breeze/settlements/entities/cats/behaviors/BaseCatBehavior.java
+++ b/src/main/java/dev/breeze/settlements/entities/cats/behaviors/BaseCatBehavior.java
@@ -1,6 +1,7 @@
 package dev.breeze.settlements.entities.cats.behaviors;
 
-import dev.breeze.settlements.utils.MessageUtil;
+import dev.breeze.settlements.entities.cats.VillagerCat;
+import dev.breeze.settlements.utils.DebugUtil;
 import dev.breeze.settlements.utils.TimeUtil;
 import lombok.Getter;
 import net.minecraft.server.level.ServerLevel;
@@ -34,7 +35,11 @@ public abstract class BaseCatBehavior extends Behavior<Cat> {
 
     @Override
     protected void start(@Nonnull ServerLevel level, @Nonnull Cat cat, long gameTime) {
-        MessageUtil.debug("&a[Debug] Cat behavior " + this.getClass().getSimpleName() + " has started");
+        if (!(cat instanceof VillagerCat villagerCat)) {
+            return;
+        }
+        DebugUtil.broadcastEntity("&aCat behavior %s has started".formatted(this.getClass().getSimpleName()), cat.getStringUUID(),
+                villagerCat.getHoverDescription());
     }
 
     @Override
@@ -50,7 +55,11 @@ public abstract class BaseCatBehavior extends Behavior<Cat> {
 
     @Override
     protected void stop(@Nonnull ServerLevel level, @Nonnull Cat cat, long gameTime) {
-        MessageUtil.debug("&c[Debug] Cat behavior " + this.getClass().getSimpleName() + " has stopped");
+        if (!(cat instanceof VillagerCat villagerCat)) {
+            return;
+        }
+        DebugUtil.broadcastEntity("&cCat behavior %s has stopped".formatted(this.getClass().getSimpleName()), cat.getStringUUID(),
+                villagerCat.getHoverDescription());
     }
 
 }

--- a/src/main/java/dev/breeze/settlements/entities/villagers/BaseVillager.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/BaseVillager.java
@@ -9,6 +9,8 @@ import dev.breeze.settlements.entities.villagers.inventory.VillagerInventory;
 import dev.breeze.settlements.entities.villagers.memories.VillagerMemory;
 import dev.breeze.settlements.entities.villagers.memories.VillagerMemoryType;
 import dev.breeze.settlements.entities.villagers.navigation.VillagerNavigation;
+import dev.breeze.settlements.entities.villagers.sensors.BaseVillagerSensor;
+import dev.breeze.settlements.entities.villagers.sensors.VillagerSensor;
 import dev.breeze.settlements.entities.villagers.sensors.VillagerSensorType;
 import dev.breeze.settlements.utils.LogUtil;
 import dev.breeze.settlements.utils.StringUtil;
@@ -175,23 +177,22 @@ public class BaseVillager extends Villager {
             final ImmutableList<SensorType<Sensor<Villager>>> DEFAULT_SENSOR_TYPES = (ImmutableList<SensorType<Sensor<Villager>>>)
                     FieldUtils.readStaticField(Villager.class, "cC", true);
 
-            ImmutableList.Builder<MemoryModuleType<?>> customMemoryTypeBuilder = new ImmutableList.Builder<MemoryModuleType<?>>()
+            // Add custom memories
+            ImmutableList.Builder<MemoryModuleType<?>> customMemoryTypes = new ImmutableList.Builder<MemoryModuleType<?>>()
                     .addAll(DEFAULT_MEMORY_TYPES);
             for (VillagerMemory<?> memory : VillagerMemoryType.ALL_MEMORIES) {
-                customMemoryTypeBuilder.add(memory.getMemoryModuleType());
+                customMemoryTypes.add(memory.getMemoryModuleType());
             }
-            ImmutableList<MemoryModuleType<?>> customMemoryTypes = customMemoryTypeBuilder.build();
 
-            ImmutableList<SensorType<? extends Sensor<Villager>>> customSensorTypes = new ImmutableList.Builder<SensorType<? extends Sensor<Villager>>>()
-                    .addAll(DEFAULT_SENSOR_TYPES)
-                    .add(VillagerSensorType.NEAREST_WATER_AREA)
-                    .add(VillagerSensorType.IS_MEAL_TIME)
-                    .add(VillagerSensorType.NEAREST_ENCHANTING_TABLE)
-                    .add(VillagerSensorType.NEAREST_HARVESTABLE_SUGARCANE)
-                    .add(VillagerSensorType.CURRENT_HABITAT)
-                    .build();
+            // Add custom sensors
+            ImmutableList.Builder<SensorType<? extends Sensor<Villager>>> customSensorTypes =
+                    new ImmutableList.Builder<SensorType<? extends Sensor<Villager>>>()
+                            .addAll(DEFAULT_SENSOR_TYPES);
+            for (VillagerSensor<? extends BaseVillagerSensor> sensor : VillagerSensorType.ALL_SENSORS) {
+                customSensorTypes.add(sensor.getSensorType());
+            }
 
-            return Brain.provider(customMemoryTypes, customSensorTypes);
+            return Brain.provider(customMemoryTypes.build(), customSensorTypes.build());
         } catch (IllegalAccessException e) {
             LogUtil.exception(e, "Encountered exception when creating custom villager brain!");
             throw new RuntimeException(e);

--- a/src/main/java/dev/breeze/settlements/entities/villagers/BaseVillager.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/BaseVillager.java
@@ -12,8 +12,10 @@ import dev.breeze.settlements.entities.villagers.navigation.VillagerNavigation;
 import dev.breeze.settlements.entities.villagers.sensors.BaseVillagerSensor;
 import dev.breeze.settlements.entities.villagers.sensors.VillagerSensor;
 import dev.breeze.settlements.entities.villagers.sensors.VillagerSensorType;
+import dev.breeze.settlements.utils.DebugUtil;
 import dev.breeze.settlements.utils.LogUtil;
 import dev.breeze.settlements.utils.StringUtil;
+import dev.breeze.settlements.utils.VillagerUtil;
 import dev.breeze.settlements.utils.itemstack.ItemStackBuilder;
 import lombok.Getter;
 import lombok.Setter;
@@ -136,7 +138,7 @@ public class BaseVillager extends Villager {
     @Override
     public void load(@Nonnull CompoundTag nbt) {
         super.load(nbt);
-        LogUtil.info("Loading custom villager...");
+        DebugUtil.log("Loading custom villager (%s)", this.getUUID().toString());
 
         // Attempt to load saved inventory data
         if (nbt.contains(INVENTORY_NBT_TAG, Tag.TAG_COMPOUND)) {
@@ -165,6 +167,11 @@ public class BaseVillager extends Villager {
         VillagerMemoryType.save(nbt, this);
     }
 
+    @Override
+    public boolean save(@Nonnull CompoundTag nbt) {
+        DebugUtil.log("Saving custom villager (%s)", this.getUUID().toString());
+        return super.save(nbt);
+    }
 
     @Override
     @SuppressWarnings("unchecked")
@@ -375,6 +382,23 @@ public class BaseVillager extends Villager {
      */
     public VillagerType getVillagerBiomeType() {
         return this.getVillagerData().getType();
+    }
+
+    /**
+     * Returns a short description of this villager, primarily used in hover messages
+     */
+    public List<String> getHoverDescription() {
+        String professionDetails = this.getProfession().name();
+        if (this.getProfession() == VillagerProfession.NONE) {
+            professionDetails = "unemployed";
+        }
+        professionDetails = "%s %s".formatted(VillagerUtil.getExpertiseName(this.getExpertiseLevel(), false), professionDetails);
+
+        return List.of(
+                "Entity type: %s".formatted(ENTITY_TYPE),
+                "Profession: %s".formatted(StringUtil.toTitleCase(professionDetails)),
+                "UUID: %s".formatted(this.getStringUUID())
+        );
     }
 
     /**

--- a/src/main/java/dev/breeze/settlements/entities/villagers/CustomVillagerBehaviorPackages.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/CustomVillagerBehaviorPackages.java
@@ -74,36 +74,20 @@ public final class CustomVillagerBehaviorPackages {
 
         // Add custom behaviors
         List<BaseVillagerBehavior> customBehaviors = new ArrayList<>();
-        BaseVillagerBehavior temp;
 
+        // Open fence gate behavior (not added to GUI)
         if (CAN_OPEN_FENCE_GATE.contains(profession)) {
             coreBehaviors.add(Pair.of(0, new InteractWithFenceGate()));
         }
 
         // Eat meals behavior
-        temp = new EatAtMealTimeBehavior();
-        coreBehaviors.add(Pair.of(4, temp));
-        customBehaviors.add(temp);
+        addBehavior(new EatAtMealTimeBehavior(), coreBehaviors, 4, customBehaviors);
 
         // Drink water behavior
-        temp = new DrinkWaterBehavior();
-        coreBehaviors.add(Pair.of(4, temp));
-        customBehaviors.add(temp);
+        addBehavior(new DrinkWaterBehavior(), coreBehaviors, 4, customBehaviors);
 
-        // Scan for pets behavior
+        // Scan for pets behavior (not added to GUI)
         coreBehaviors.add(Pair.of(20, ScanForPetsBehaviorController.scanForPets()));
-
-        // TODO: refactor this into other activities
-        if (profession == VillagerProfession.NITWIT) {
-            ArrayList<Pair<? extends BehaviorControl<? super Villager>, Integer>> nitwitBehaviors = new ArrayList<>();
-            nitwitBehaviors.add(Pair.of(new LaunchFireworkBehavior(), 1));
-            nitwitBehaviors.add(Pair.of(new ThrowSnowballBehavior(), 1));
-            nitwitBehaviors.add(Pair.of(new RingBellBehavior(), 1));
-            nitwitBehaviors.add(Pair.of(new RunAroundBehavior(), 1));
-
-            // Add to core behaviors
-            coreBehaviors.add(Pair.of(30, new RunOne<>(nitwitBehaviors)));
-        }
 
         // Return behaviors
         return new BehaviorContainer(ImmutableList.copyOf(coreBehaviors), customBehaviors);
@@ -113,10 +97,10 @@ public final class CustomVillagerBehaviorPackages {
      * Work activity behaviors
      */
     public static BehaviorContainer getWorkPackage(VillagerProfession profession, float speed) {
-        ArrayList<Pair<? extends BehaviorControl<? super Villager>, Integer>> workBehaviors = new ArrayList<>();
+        ArrayList<Pair<? extends BehaviorControl<? super Villager>, Integer>> workChoiceBehaviors = new ArrayList<>();
 
         // Add default behaviors
-        workBehaviors.addAll(List.of(
+        workChoiceBehaviors.addAll(List.of(
                 Pair.of(profession == VillagerProfession.FARMER ? new WorkAtComposter() : new WorkAtPoi(), 7),
                 Pair.of(StrollAroundPoi.create(MemoryModuleType.JOB_SITE, STROLL_SPEED_MODIFIER, 4), 2),
                 Pair.of(StrollToPoi.create(MemoryModuleType.JOB_SITE, STROLL_SPEED_MODIFIER, 1, 10), 5),
@@ -125,109 +109,71 @@ public final class CustomVillagerBehaviorPackages {
                 Pair.of(new UseBonemeal(), profession == VillagerProfession.FARMER ? 4 : 7)
         ));
 
-        // Assign custom work behaviors based on profession
-        List<BaseVillagerBehavior> customBehaviors = new ArrayList<>();
-        BaseVillagerBehavior temp;
+        /*
+         * Assign custom work behaviors based on profession
+         */
 
+        // Map of { behavior => weight of behavior }
+        Map<BaseVillagerBehavior, Integer> customBehaviorWeightMap = new HashMap<>();
         int customGoalWeight = 10;
+
         if (profession == VillagerProfession.NONE || profession == VillagerProfession.NITWIT) {
             // Unreachable code, because villager does not have job site
         } else if (profession == VillagerProfession.ARMORER) {
-            temp = new RepairIronGolemBehavior();
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
+            customBehaviorWeightMap.put(new RepairIronGolemBehavior(), customGoalWeight);
         } else if (profession == VillagerProfession.BUTCHER) {
-            temp = new TameWolfBehavior();
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
-
-            temp = new BreedAnimalsBehavior(Set.of(EntityType.COW, EntityType.PIG, EntityType.RABBIT));
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
-
-            temp = new ButcherAnimalsBehavior(Map.of(
+            customBehaviorWeightMap.put(new TameWolfBehavior(), customGoalWeight);
+            customBehaviorWeightMap.put(new BreedAnimalsBehavior(Set.of(EntityType.COW, EntityType.PIG, EntityType.RABBIT)), customGoalWeight);
+            customBehaviorWeightMap.put(new ButcherAnimalsBehavior(Map.of(
                     EntityType.COW, 3,
                     EntityType.SHEEP, 5,
                     EntityType.CHICKEN, 3,
                     EntityType.PIG, 2,
                     EntityType.RABBIT, 2
-            ));
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
+            )), customGoalWeight);
         } else if (profession == VillagerProfession.CARTOGRAPHER) {
-
+            // TODO: add behavior
         } else if (profession == VillagerProfession.CLERIC) {
-
+            // TODO: add behavior
         } else if (profession == VillagerProfession.FARMER) {
-            temp = new HarvestSugarcaneBehavior();
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
-
-            temp = new TameWolfBehavior();
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
-
-            temp = new TameCatBehavior();
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
-
-            temp = new BreedAnimalsBehavior(Set.of(EntityType.CHICKEN));
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
+            customBehaviorWeightMap.put(new HarvestSugarcaneBehavior(), customGoalWeight);
+            customBehaviorWeightMap.put(new TameWolfBehavior(), customGoalWeight);
+            customBehaviorWeightMap.put(new TameCatBehavior(), customGoalWeight);
+            customBehaviorWeightMap.put(new BreedAnimalsBehavior(Set.of(EntityType.CHICKEN)), customGoalWeight);
         } else if (profession == VillagerProfession.FISHERMAN) {
-            temp = new TameCatBehavior();
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
-
-            temp = new FishingBehavior();
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
+            customBehaviorWeightMap.put(new TameCatBehavior(), customGoalWeight);
+            customBehaviorWeightMap.put(new FishingBehavior(), customGoalWeight);
         } else if (profession == VillagerProfession.FLETCHER) {
             // TODO: pluck feather from chicken
-            temp = new BreedAnimalsBehavior(Set.of(EntityType.CHICKEN));
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
+            customBehaviorWeightMap.put(new BreedAnimalsBehavior(Set.of(EntityType.CHICKEN)), customGoalWeight);
         } else if (profession == VillagerProfession.LEATHERWORKER) {
-            temp = new TameWolfBehavior();
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
-
-            temp = new BreedAnimalsBehavior(Set.of(EntityType.COW));
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
+            customBehaviorWeightMap.put(new TameWolfBehavior(), customGoalWeight);
+            customBehaviorWeightMap.put(new BreedAnimalsBehavior(Set.of(EntityType.COW)), customGoalWeight);
         } else if (profession == VillagerProfession.LIBRARIAN) {
-            temp = new EnchantItemBehavior();
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
+            customBehaviorWeightMap.put(new EnchantItemBehavior(), customGoalWeight);
         } else if (profession == VillagerProfession.MASON) {
-
+            // TODO: add behavior
         } else if (profession == VillagerProfession.SHEPHERD) {
-            temp = new TameWolfBehavior();
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
-
-            temp = new ShearSheepBehavior();
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
-
-            temp = new BreedAnimalsBehavior(Set.of(EntityType.SHEEP));
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
+            customBehaviorWeightMap.put(new TameWolfBehavior(), customGoalWeight);
+            customBehaviorWeightMap.put(new ShearSheepBehavior(), customGoalWeight);
+            customBehaviorWeightMap.put(new BreedAnimalsBehavior(Set.of(EntityType.SHEEP)), customGoalWeight);
         } else if (profession == VillagerProfession.TOOLSMITH) {
-            temp = new RepairIronGolemBehavior();
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
+            customBehaviorWeightMap.put(new RepairIronGolemBehavior(), customGoalWeight);
         } else if (profession == VillagerProfession.WEAPONSMITH) {
-            temp = new RepairIronGolemBehavior();
-            workBehaviors.add(Pair.of(temp, customGoalWeight));
-            customBehaviors.add(temp);
+            customBehaviorWeightMap.put(new RepairIronGolemBehavior(), customGoalWeight);
+        }
+
+        // Add custom behaviors
+        List<BaseVillagerBehavior> customBehaviors = new ArrayList<>();
+        for (Map.Entry<BaseVillagerBehavior, Integer> entry : customBehaviorWeightMap.entrySet()) {
+            addChoiceBehavior(entry.getKey(), workChoiceBehaviors, entry.getValue(), customBehaviors);
         }
 
         ImmutableList<Pair<Integer, ? extends BehaviorControl<? super Villager>>> behaviors = ImmutableList.of(
                 getMinimalLookBehavior(),
                 Pair.of(2, CustomSetWalkTargetFromBlockMemory.create(MemoryModuleType.JOB_SITE, speed, 9, 100, 1200)),
                 Pair.of(3, new GiveGiftToHero(100)),
-                Pair.of(5, new RunOne<>(workBehaviors)),
+                Pair.of(5, new RunOne<>(workChoiceBehaviors)),
                 Pair.of(10, new ShowTradesToPlayer(400, 1600)),
                 Pair.of(10, SetLookAndInteract.create(EntityType.PLAYER, 4)),
                 Pair.of(99, UpdateActivityFromSchedule.create())
@@ -278,45 +224,43 @@ public final class CustomVillagerBehaviorPackages {
     }
 
     public static BehaviorContainer getMeetPackage(VillagerProfession profession, float speed) {
-        ArrayList<Pair<? extends BehaviorControl<? super Villager>, Integer>> customMeetBehaviors = new ArrayList<>();
+        ArrayList<Pair<? extends BehaviorControl<? super Villager>, Integer>> customMeetChoiceBehaviors = new ArrayList<>();
 
-        // Add custom behaviors
+        // Custom behavior container
         List<BaseVillagerBehavior> customBehaviors = new ArrayList<>();
-        BaseVillagerBehavior temp;
 
         // Feed wolf behavior
         if (profession == VillagerProfession.BUTCHER) {
-            temp = new FeedWolfBehavior();
-            customMeetBehaviors.add(Pair.of(temp, 1));
-            customBehaviors.add(temp);
+            addChoiceBehavior(new FeedWolfBehavior(), customMeetChoiceBehaviors, 1, customBehaviors);
         }
 
         // Tame wolf behavior
         if (profession == VillagerProfession.SHEPHERD || profession == VillagerProfession.FARMER || profession == VillagerProfession.LEATHERWORKER
                 || profession == VillagerProfession.BUTCHER) {
-            temp = new TameWolfBehavior();
-            customMeetBehaviors.add(Pair.of(temp, 1));
-            customBehaviors.add(temp);
+            addChoiceBehavior(new TameWolfBehavior(), customMeetChoiceBehaviors, 1, customBehaviors);
         }
 
         // Tame cat behavior
         if (profession == VillagerProfession.FARMER || profession == VillagerProfession.FISHERMAN) {
-            temp = new TameCatBehavior();
-            customMeetBehaviors.add(Pair.of(temp, 1));
-            customBehaviors.add(temp);
+            addChoiceBehavior(new TameCatBehavior(), customMeetChoiceBehaviors, 1, customBehaviors);
         }
 
         // Throw healing potion behavior
         if (profession == VillagerProfession.CLERIC) {
-            temp = new ThrowHealingPotionBehavior();
-            customMeetBehaviors.add(Pair.of(temp, 1));
-            customBehaviors.add(temp);
+            addChoiceBehavior(new ThrowHealingPotionBehavior(), customMeetChoiceBehaviors, 1, customBehaviors);
         }
+
+        // Nitwit behaviors
+        if (profession == VillagerProfession.NITWIT) {
+            addChoiceBehavior(new RingBellBehavior(), customMeetChoiceBehaviors, 1, customBehaviors);
+            addChoiceBehavior(new LaunchFireworkBehavior(), customMeetChoiceBehaviors, 1, customBehaviors);
+        }
+
 
         // Default behaviors
         ImmutableList<Pair<Integer, ? extends BehaviorControl<? super Villager>>> behaviors = ImmutableList.of(
                 getFullLookBehavior(),
-                Pair.of(1, new RunOne<>(customMeetBehaviors)),
+                Pair.of(1, new RunOne<>(customMeetChoiceBehaviors)),
                 Pair.of(2, TriggerGate.triggerOneShuffled(ImmutableList.of(
                         Pair.of(StrollAroundPoi.create(MemoryModuleType.MEETING_POINT, STROLL_SPEED_MODIFIER, 40), 2),
                         Pair.of(SocializeAtBell.create(), 2)
@@ -348,7 +292,6 @@ public final class CustomVillagerBehaviorPackages {
                 Pair.of(3, new GateBehavior<>(ImmutableMap.of(), ImmutableSet.of(MemoryModuleType.BREED_TARGET), GateBehavior.OrderPolicy.ORDERED,
                         GateBehavior.RunningPolicy.RUN_ONE, ImmutableList.of(Pair.of(new VillagerMakeLove(), 1)))),
                 Pair.of(99, UpdateActivityFromSchedule.create())
-
         ));
 
         // Default behaviors that will be randomly chosen to run one
@@ -363,35 +306,38 @@ public final class CustomVillagerBehaviorPackages {
                 Pair.of(new DoNothing(30, 60), 1)
         ));
 
-        // Add custom behaviors
-        BaseVillagerBehavior temp;
-
+        /*
+         * Add custom behaviors
+         */
         // Custom wolf-related behaviors
         if (profession == VillagerProfession.SHEPHERD || profession == VillagerProfession.FARMER || profession == VillagerProfession.LEATHERWORKER
                 || profession == VillagerProfession.BUTCHER) {
             // Add parallel-running behaviors
-            temp = new WalkDogBehavior();
-            idleBehaviors.add(Pair.of(1, temp));
-            customBehaviors.add(temp);
+            addBehavior(new WalkDogBehavior(), idleBehaviors, 1, customBehaviors);
 
             // Add choice behaviors
             for (BaseVillagerBehavior behavior : List.of(
                     new TameWolfBehavior(),
                     new WashWolfBehavior()
             )) {
-                idleChoiceBehaviors.add(Pair.of(behavior, 10));
-                customBehaviors.add(behavior);
+                addChoiceBehavior(behavior, idleChoiceBehaviors, 10, customBehaviors);
             }
         }
 
         // Tame cat behavior (cat should be resting now, so no other behaviors)
         if (profession == VillagerProfession.FARMER || profession == VillagerProfession.FISHERMAN) {
-            temp = new TameCatBehavior();
-            idleChoiceBehaviors.add(Pair.of(temp, 10));
-            customBehaviors.add(temp);
+            addChoiceBehavior(new TameCatBehavior(), idleChoiceBehaviors, 10, customBehaviors);
         }
 
-        // Add choice behaviors
+        // Nitwit behaviors
+        if (profession == VillagerProfession.NITWIT) {
+            // Add parallel-running behaviors
+            addBehavior(new LaunchFireworkBehavior(), idleBehaviors, 1, customBehaviors);
+            addBehavior(new ThrowSnowballBehavior(), idleBehaviors, 1, customBehaviors);
+            addBehavior(new RunAroundBehavior(), idleBehaviors, 1, customBehaviors);
+        }
+
+        // Add choice behaviors to Minecraft behaviors
         idleBehaviors.add(Pair.of(2, new RunOne<>(idleChoiceBehaviors)));
 
         return new BehaviorContainer(ImmutableList.copyOf(idleBehaviors), customBehaviors);
@@ -485,6 +431,23 @@ public final class CustomVillagerBehaviorPackages {
     private static boolean raidWon(ServerLevel world, LivingEntity entity) {
         Raid raid = world.getRaidAt(entity.blockPosition());
         return raid != null && raid.isVictory();
+    }
+
+    /*
+     * Utility methods
+     */
+    private static void addBehavior(BaseVillagerBehavior behavior,
+                                    List<Pair<Integer, ? extends BehaviorControl<? super Villager>>> minecraftBehaviors, int weight,
+                                    List<BaseVillagerBehavior> settlementBehaviors) {
+        minecraftBehaviors.add(Pair.of(weight, behavior));
+        settlementBehaviors.add(behavior);
+    }
+
+    private static void addChoiceBehavior(BaseVillagerBehavior behavior,
+                                          List<Pair<? extends BehaviorControl<? super Villager>, Integer>> choiceBehaviors, int weight,
+                                          List<BaseVillagerBehavior> settlementBehaviors) {
+        choiceBehaviors.add(Pair.of(behavior, weight));
+        settlementBehaviors.add(behavior);
     }
 
     /**

--- a/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/BaseVillagerBehavior.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/BaseVillagerBehavior.java
@@ -1,6 +1,7 @@
 package dev.breeze.settlements.entities.villagers.behaviors;
 
-import dev.breeze.settlements.utils.MessageUtil;
+import dev.breeze.settlements.entities.villagers.BaseVillager;
+import dev.breeze.settlements.utils.DebugUtil;
 import dev.breeze.settlements.utils.TimeUtil;
 import dev.breeze.settlements.utils.itemstack.ItemStackBuilder;
 import lombok.Getter;
@@ -37,23 +38,35 @@ public abstract class BaseVillagerBehavior extends Behavior<Villager> {
 
     @Override
     protected final boolean checkExtraStartConditions(@Nonnull ServerLevel world, @Nonnull Villager villager) {
+        if (!(villager instanceof BaseVillager baseVillager)) {
+            return false;
+        }
+
         if (--this.startConditionCheckCooldown > 0)
             return false;
 
         this.startConditionCheckCooldown = this.maxStartConditionCheckCooldown;
-        return this.checkExtraStartConditionsRateLimited(world, villager);
+        return this.checkExtraStartConditionsRateLimited(world, baseVillager);
     }
 
-    protected abstract boolean checkExtraStartConditionsRateLimited(@Nonnull ServerLevel world, @Nonnull Villager villager);
+    protected abstract boolean checkExtraStartConditionsRateLimited(@Nonnull ServerLevel world, @Nonnull BaseVillager villager);
 
     @Override
     protected void start(@Nonnull ServerLevel level, @Nonnull Villager villager, long gameTime) {
-        MessageUtil.debug("&a[Debug] Villager behavior " + this.getClass().getSimpleName() + " has started");
+        if (!(villager instanceof BaseVillager baseVillager)) {
+            return;
+        }
+        DebugUtil.broadcastEntity("&aVillager behavior %s has started".formatted(this.getClass().getSimpleName()), villager.getStringUUID(),
+                baseVillager.getHoverDescription());
     }
 
     @Override
     protected void stop(@Nonnull ServerLevel level, @Nonnull Villager villager, long gameTime) {
-        MessageUtil.debug("&c[Debug] Villager behavior " + this.getClass().getSimpleName() + " has stopped");
+        if (!(villager instanceof BaseVillager baseVillager)) {
+            return;
+        }
+        DebugUtil.broadcastEntity("&cVillager behavior %s has stopped".formatted(this.getClass().getSimpleName()), villager.getStringUUID(),
+                baseVillager.getHoverDescription());
     }
 
     /**

--- a/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/EatAtMealTimeBehavior.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/EatAtMealTimeBehavior.java
@@ -28,6 +28,8 @@ public final class EatAtMealTimeBehavior extends BaseVillagerBehavior {
     private static final ItemStack BREAD = CraftItemStack.asNMSCopy(new ItemStackBuilder(Material.BREAD).build());
     private static final ItemStack WATER_BOTTLE = CraftItemStack.asNMSCopy(new ItemStackBuilder(Material.POTION).build());
 
+    private static final int SCAN_COOLDOWN = TimeUtil.seconds(30);
+
     private static final int MIN_EAT_DURATION = TimeUtil.seconds(1);
     private static final int MAX_EAT_DURATION = TimeUtil.seconds(3);
     private static final int MIN_DRINK_DURATION = TimeUtil.seconds(1);
@@ -53,7 +55,7 @@ public final class EatAtMealTimeBehavior extends BaseVillagerBehavior {
         super(Map.of(
                 // Only run in meal times
                 VillagerMemoryType.IS_MEAL_TIME.getMemoryModuleType(), MemoryStatus.VALUE_PRESENT
-        ), MAX_EAT_DURATION + MAX_DRINK_DURATION);
+        ), MAX_EAT_DURATION + MAX_DRINK_DURATION, SCAN_COOLDOWN);
 
         this.cooldown = this.randomCooldown();
         this.eatTimeLeft = 0;

--- a/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/EatAtMealTimeBehavior.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/EatAtMealTimeBehavior.java
@@ -2,7 +2,7 @@ package dev.breeze.settlements.entities.villagers.behaviors;
 
 import dev.breeze.settlements.entities.villagers.BaseVillager;
 import dev.breeze.settlements.entities.villagers.memories.VillagerMemoryType;
-import dev.breeze.settlements.utils.MessageUtil;
+import dev.breeze.settlements.utils.DebugUtil;
 import dev.breeze.settlements.utils.RandomUtil;
 import dev.breeze.settlements.utils.SoundUtil;
 import dev.breeze.settlements.utils.TimeUtil;
@@ -65,10 +65,11 @@ public final class EatAtMealTimeBehavior extends BaseVillagerBehavior {
     }
 
     @Override
-    protected boolean checkExtraStartConditionsRateLimited(@Nonnull ServerLevel level, @Nonnull Villager villager) {
+    protected boolean checkExtraStartConditionsRateLimited(@Nonnull ServerLevel level, @Nonnull BaseVillager baseVillager) {
         // Not -1 because this method is rate limited
         this.cooldown -= this.getMaxStartConditionCheckCooldown();
-        MessageUtil.debug("&b[Debug] Cooldown for " + this.getClass().getSimpleName() + " is " + this.cooldown);
+        DebugUtil.broadcastEntity("&7Cooldown for %s is %s".formatted(this.getClass().getSimpleName(), TimeUtil.ticksToReadableTime(Math.max(0,
+                this.cooldown))), baseVillager.getStringUUID(), baseVillager.getHoverDescription());
         return this.cooldown <= 0;
     }
 

--- a/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/InteractAtTargetBehavior.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/InteractAtTargetBehavior.java
@@ -1,8 +1,8 @@
 package dev.breeze.settlements.entities.villagers.behaviors;
 
 import dev.breeze.settlements.entities.villagers.BaseVillager;
+import dev.breeze.settlements.utils.DebugUtil;
 import dev.breeze.settlements.utils.LogUtil;
-import dev.breeze.settlements.utils.MessageUtil;
 import dev.breeze.settlements.utils.RandomUtil;
 import dev.breeze.settlements.utils.TimeUtil;
 import lombok.Getter;
@@ -113,13 +113,14 @@ public abstract class InteractAtTargetBehavior extends BaseVillagerBehavior {
     }
 
     @Override
-    protected final boolean checkExtraStartConditionsRateLimited(@Nonnull ServerLevel level, @Nonnull Villager villager) {
+    protected final boolean checkExtraStartConditionsRateLimited(@Nonnull ServerLevel level, @Nonnull BaseVillager baseVillager) {
         // Not -1 because this method is rate limited
         this.cooldown -= this.getMaxStartConditionCheckCooldown();
-        MessageUtil.debug("&b[Debug] Cooldown for " + this.getClass().getSimpleName() + " is " + this.cooldown);
+        DebugUtil.broadcastEntity("&7Cooldown for %s is %s".formatted(this.getClass().getSimpleName(), TimeUtil.ticksToReadableTime(Math.max(0,
+                this.cooldown))), baseVillager.getStringUUID(), baseVillager.getHoverDescription());
         if (this.cooldown > 0)
             return false;
-        return this.scan(level, villager);
+        return this.scan(level, baseVillager);
     }
 
     /**

--- a/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/WalkDogBehavior.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/WalkDogBehavior.java
@@ -34,7 +34,7 @@ public final class WalkDogBehavior extends BaseVillagerBehavior {
     }
 
     @Override
-    protected boolean checkExtraStartConditionsRateLimited(@Nonnull ServerLevel level, @Nonnull Villager villager) {
+    protected boolean checkExtraStartConditionsRateLimited(@Nonnull ServerLevel level, @Nonnull BaseVillager baseVillager) {
         return true;
     }
 

--- a/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/habitat/desert/DrinkWaterBehavior.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/habitat/desert/DrinkWaterBehavior.java
@@ -28,6 +28,7 @@ public final class DrinkWaterBehavior extends BaseVillagerBehavior {
                     .setBasePotionEffect(new PotionData(PotionType.WATER))
                     .build());
 
+    private static final int SCAN_COOLDOWN = TimeUtil.minutes(1);
     public static final int TICK_INTERVAL = TimeUtil.ticks(5);
 
     private static final int MIN_OVERHEAT_DURATION = TimeUtil.seconds(5);
@@ -44,7 +45,7 @@ public final class DrinkWaterBehavior extends BaseVillagerBehavior {
     public DrinkWaterBehavior() {
         super(Map.of(
                 VillagerMemoryType.CURRENT_HABITAT.getMemoryModuleType(), MemoryStatus.VALUE_PRESENT
-        ), MAX_OVERHEAT_DURATION + DRINK_DURATION);
+        ), MAX_OVERHEAT_DURATION + DRINK_DURATION, SCAN_COOLDOWN);
 
         this.cooldown = this.randomCooldown();
         this.overheatTimeLeft = 0;

--- a/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/habitat/desert/DrinkWaterBehavior.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/habitat/desert/DrinkWaterBehavior.java
@@ -53,16 +53,17 @@ public final class DrinkWaterBehavior extends BaseVillagerBehavior {
     }
 
     @Override
-    protected boolean checkExtraStartConditionsRateLimited(@Nonnull ServerLevel level, @Nonnull Villager villager) {
+    protected boolean checkExtraStartConditionsRateLimited(@Nonnull ServerLevel level, @Nonnull BaseVillager baseVillager) {
         // Not -1 because this method is rate limited
         this.cooldown -= this.getMaxStartConditionCheckCooldown();
-        MessageUtil.debug("&b[Debug] Cooldown for " + this.getClass().getSimpleName() + " is " + this.cooldown);
+        DebugUtil.broadcastEntity("&7Cooldown for %s is %s".formatted(this.getClass().getSimpleName(), TimeUtil.ticksToReadableTime(Math.max(0,
+                this.cooldown))), baseVillager.getStringUUID(), baseVillager.getHoverDescription());
         if (this.cooldown > 0) {
             return false;
         }
 
         // Check if it's a hot habitat
-        Habitat habitat = VillagerMemoryType.CURRENT_HABITAT.get(villager.getBrain());
+        Habitat habitat = VillagerMemoryType.CURRENT_HABITAT.get(baseVillager.getBrain());
         return habitat != null && habitat.isHot();
     }
 

--- a/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/pranks/RunAroundBehavior.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/behaviors/pranks/RunAroundBehavior.java
@@ -3,7 +3,7 @@ package dev.breeze.settlements.entities.villagers.behaviors.pranks;
 import dev.breeze.settlements.config.files.NitwitPranksConfig;
 import dev.breeze.settlements.entities.villagers.BaseVillager;
 import dev.breeze.settlements.entities.villagers.behaviors.BaseVillagerBehavior;
-import dev.breeze.settlements.utils.MessageUtil;
+import dev.breeze.settlements.utils.DebugUtil;
 import dev.breeze.settlements.utils.RandomUtil;
 import dev.breeze.settlements.utils.SoundUtil;
 import dev.breeze.settlements.utils.TimeUtil;
@@ -51,10 +51,11 @@ public final class RunAroundBehavior extends BaseVillagerBehavior {
     }
 
     @Override
-    protected boolean checkExtraStartConditionsRateLimited(@Nonnull ServerLevel level, @Nonnull Villager villager) {
+    protected boolean checkExtraStartConditionsRateLimited(@Nonnull ServerLevel level, @Nonnull BaseVillager baseVillager) {
         // Not -1 because this method is rate limited
         this.cooldown -= this.getMaxStartConditionCheckCooldown();
-        MessageUtil.debug("&b[Debug] Cooldown for " + this.getClass().getSimpleName() + " is " + this.cooldown);
+        DebugUtil.broadcastEntity("&7Cooldown for %s is %s".formatted(this.getClass().getSimpleName(), TimeUtil.ticksToReadableTime(Math.max(0,
+                this.cooldown))), baseVillager.getStringUUID(), baseVillager.getHoverDescription());
         return this.cooldown <= 0;
     }
 

--- a/src/main/java/dev/breeze/settlements/entities/villagers/memories/VillagerMemoryType.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/memories/VillagerMemoryType.java
@@ -129,7 +129,7 @@ public class VillagerMemoryType {
 
     public static final VillagerMemory<Boolean> IS_MEAL_TIME = VillagerMemory.<Boolean>builder()
             .identifier("meal_time")
-            .parser(memory -> Collections.singletonList(memory ? "Yes" : "No"))
+            .parser(memory -> Collections.singletonList(memory ? "&aYes" : "&cNo"))
             .serializer(null)
             .clickEventHandler(null)
             .displayName("Meal time")

--- a/src/main/java/dev/breeze/settlements/entities/villagers/memories/VillagerMemoryType.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/memories/VillagerMemoryType.java
@@ -1,6 +1,7 @@
 package dev.breeze.settlements.entities.villagers.memories;
 
 import dev.breeze.settlements.entities.villagers.BaseVillager;
+import dev.breeze.settlements.entities.villagers.sensors.VillagerMealTimeSensor;
 import dev.breeze.settlements.entities.wolves.VillagerWolf;
 import dev.breeze.settlements.utils.Habitat;
 import dev.breeze.settlements.utils.LogUtil;
@@ -135,9 +136,9 @@ public class VillagerMemoryType {
             .description(List.of(
                     "&fIs it a good time to eat now?",
                     "&fMeal times:",
-                    "&7- Breakfast: 1800 - 2200 ticks",
-                    "&7- Lunch: 5800 - 6200 ticks",
-                    "&7- Dinner: 10800 - 11200 ticks"
+                    "&7- Breakfast: %d - %d ticks".formatted(VillagerMealTimeSensor.BREAKFAST_START, VillagerMealTimeSensor.BREAKFAST_END),
+                    "&7- Lunch: %d - %d ticks".formatted(VillagerMealTimeSensor.LUNCH_START, VillagerMealTimeSensor.LUNCH_END),
+                    "&7- Dinner: %d - %d ticks".formatted(VillagerMealTimeSensor.DINNER_START, VillagerMealTimeSensor.DINNER_END)
             ))
             .itemMaterial(Material.BREAD)
             .build();

--- a/src/main/java/dev/breeze/settlements/entities/villagers/sensors/BaseVillagerSensor.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/sensors/BaseVillagerSensor.java
@@ -1,7 +1,7 @@
 package dev.breeze.settlements.entities.villagers.sensors;
 
 import dev.breeze.settlements.entities.villagers.BaseVillager;
-import dev.breeze.settlements.utils.MessageUtil;
+import dev.breeze.settlements.utils.DebugUtil;
 import dev.breeze.settlements.utils.TimeUtil;
 import dev.breeze.settlements.utils.itemstack.ItemStackBuilder;
 import net.minecraft.server.level.ServerLevel;
@@ -30,7 +30,8 @@ public abstract class BaseVillagerSensor extends Sensor<Villager> {
             return;
         }
 
-        MessageUtil.debug("&6[Debug] Ticking sensor " + this.getClass().getSimpleName() + "!");
+        DebugUtil.broadcastEntity("&6Ticking sensor %s!".formatted(this.getClass().getSimpleName()), villager.getStringUUID(),
+                baseVillager.getHoverDescription());
         this.tickSensor(world, baseVillager, baseVillager.getBrain());
     }
 

--- a/src/main/java/dev/breeze/settlements/entities/villagers/sensors/BaseVillagerSensor.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/sensors/BaseVillagerSensor.java
@@ -1,0 +1,57 @@
+package dev.breeze.settlements.entities.villagers.sensors;
+
+import dev.breeze.settlements.entities.villagers.BaseVillager;
+import dev.breeze.settlements.utils.MessageUtil;
+import dev.breeze.settlements.utils.TimeUtil;
+import dev.breeze.settlements.utils.itemstack.ItemStackBuilder;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.Brain;
+import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.ai.sensing.Sensor;
+import net.minecraft.world.entity.npc.Villager;
+
+import javax.annotation.Nonnull;
+import java.util.Set;
+
+public abstract class BaseVillagerSensor extends Sensor<Villager> {
+
+    private final int senseCooldown;
+
+    public BaseVillagerSensor(int senseCooldown) {
+        super(senseCooldown);
+
+        this.senseCooldown = senseCooldown;
+    }
+
+    @Override
+    protected final void doTick(@Nonnull ServerLevel world, @Nonnull Villager villager) {
+        // Villager type check
+        if (!(villager instanceof BaseVillager baseVillager)) {
+            return;
+        }
+
+        MessageUtil.debug("&6[Debug] Ticking sensor " + this.getClass().getSimpleName() + "!");
+        this.tickSensor(world, baseVillager, baseVillager.getBrain());
+    }
+
+    protected abstract void tickSensor(@Nonnull ServerLevel world, @Nonnull BaseVillager villager, @Nonnull Brain<Villager> brain);
+
+    @Override
+    @Nonnull
+    public abstract Set<MemoryModuleType<?>> requires();
+
+    @Nonnull
+    public final ItemStackBuilder getGuiItemBuilder() {
+        ItemStackBuilder builder = this.getGuiItemBuilderAbstract();
+
+        builder.appendLore("&7---");
+        builder.appendLore("&7Related memory: %s".formatted(this.requires().toString()));
+        builder.appendLore("&7Interval: %s".formatted(TimeUtil.ticksToReadableTime(this.senseCooldown)));
+
+        return builder;
+    }
+
+    @Nonnull
+    public abstract ItemStackBuilder getGuiItemBuilderAbstract();
+
+}

--- a/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerHabitatSensor.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerHabitatSensor.java
@@ -1,29 +1,30 @@
 package dev.breeze.settlements.entities.villagers.sensors;
 
+import dev.breeze.settlements.entities.villagers.BaseVillager;
 import dev.breeze.settlements.entities.villagers.memories.VillagerMemoryType;
 import dev.breeze.settlements.utils.Habitat;
 import dev.breeze.settlements.utils.TimeUtil;
+import dev.breeze.settlements.utils.itemstack.ItemStackBuilder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
-import net.minecraft.world.entity.ai.sensing.Sensor;
 import net.minecraft.world.entity.npc.Villager;
+import org.bukkit.Material;
 import org.bukkit.block.Biome;
 
 import javax.annotation.Nonnull;
 import java.util.Set;
 
-public class VillagerHabitatSensor extends Sensor<Villager> {
+public class VillagerHabitatSensor extends BaseVillagerSensor {
 
-    private static final int SENSE_COOLDOWN = TimeUtil.seconds(10); // TODO: 5 minutes
+    private static final int SENSE_COOLDOWN = TimeUtil.minutes(5);
 
     public VillagerHabitatSensor() {
         super(SENSE_COOLDOWN);
     }
 
     @Override
-    protected void doTick(@Nonnull ServerLevel world, @Nonnull Villager villager) {
-        Brain<Villager> brain = villager.getBrain();
+    protected void tickSensor(@Nonnull ServerLevel world, @Nonnull BaseVillager villager, @Nonnull Brain<Villager> brain) {
         Biome biome = world.getWorld().getBiome(villager.getBlockX(), villager.getBlockZ());
         VillagerMemoryType.CURRENT_HABITAT.set(brain, Habitat.fromBiome(biome));
     }
@@ -33,5 +34,14 @@ public class VillagerHabitatSensor extends Sensor<Villager> {
     public Set<MemoryModuleType<?>> requires() {
         return Set.of(VillagerMemoryType.CURRENT_HABITAT.getMemoryModuleType());
     }
+
+    @Nonnull
+    @Override
+    public ItemStackBuilder getGuiItemBuilderAbstract() {
+        return new ItemStackBuilder(Material.GRASS_BLOCK)
+                .setDisplayName("&eCurrent habitat sensor")
+                .setLore("&fOccasionally checks what biome the villager is currently in");
+    }
+
 
 }

--- a/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerMealTimeSensor.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerMealTimeSensor.java
@@ -1,38 +1,46 @@
 package dev.breeze.settlements.entities.villagers.sensors;
 
+import dev.breeze.settlements.entities.villagers.BaseVillager;
 import dev.breeze.settlements.entities.villagers.memories.VillagerMemoryType;
 import dev.breeze.settlements.utils.TimeUtil;
+import dev.breeze.settlements.utils.itemstack.ItemStackBuilder;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
-import net.minecraft.world.entity.ai.sensing.Sensor;
 import net.minecraft.world.entity.npc.Villager;
+import org.bukkit.Material;
 
 import javax.annotation.Nonnull;
 import java.util.Set;
 
-public class VillagerMealTimeSensor extends Sensor<Villager> {
+public class VillagerMealTimeSensor extends BaseVillagerSensor {
 
-    private static final int SENSE_COOLDOWN = TimeUtil.seconds(10);
+    private static final int SENSE_COOLDOWN = TimeUtil.seconds(30);
+
+    // Meal times
+    public static final int BREAKFAST_START = 1800;
+    public static final int BREAKFAST_END = 2200;
+    public static final int LUNCH_START = 5800;
+    public static final int LUNCH_END = 6200;
+    public static final int DINNER_START = 10800;
+    public static final int DINNER_END = 11200;
 
     public VillagerMealTimeSensor() {
         super(SENSE_COOLDOWN);
     }
 
     @Override
-    protected void doTick(@Nonnull ServerLevel world, @Nonnull Villager villager) {
-        Brain<Villager> brain = villager.getBrain();
-
+    protected void tickSensor(@Nonnull ServerLevel world, @Nonnull BaseVillager villager, @Nonnull Brain<Villager> brain) {
         long timeOfDay = world.getLevel().getWorld().getTime();
         boolean isMealTime = false;
 
-        if (timeOfDay > 1800 && timeOfDay < 2200) {
+        if (timeOfDay > BREAKFAST_START && timeOfDay < BREAKFAST_END) {
             // Breakfast
             isMealTime = true;
-        } else if (timeOfDay > 5800 && timeOfDay < 6200) {
+        } else if (timeOfDay > LUNCH_START && timeOfDay < LUNCH_END) {
             // Lunch
             isMealTime = true;
-        } else if (timeOfDay > 10800 && timeOfDay < 11200) {
+        } else if (timeOfDay > DINNER_START && timeOfDay < DINNER_END) {
             // Dinner
             isMealTime = true;
         }
@@ -45,6 +53,20 @@ public class VillagerMealTimeSensor extends Sensor<Villager> {
     @Nonnull
     public Set<MemoryModuleType<?>> requires() {
         return Set.of(VillagerMemoryType.IS_MEAL_TIME.getMemoryModuleType());
+    }
+
+    @Nonnull
+    @Override
+    public ItemStackBuilder getGuiItemBuilderAbstract() {
+        return new ItemStackBuilder(Material.BREAD)
+                .setDisplayName("&eMeal time sensor")
+                .setLore(
+                        "&fChecks if it's time to eat yet",
+                        "&fMeal times:",
+                        "&7- Breakfast: %d - %d ticks".formatted(BREAKFAST_START, BREAKFAST_END),
+                        "&7- Lunch: %d - %d ticks".formatted(LUNCH_START, LUNCH_END),
+                        "&7- Dinner: %d - %d ticks".formatted(DINNER_START, DINNER_END)
+                );
     }
 
 }

--- a/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerNearbyBlockSensor.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerNearbyBlockSensor.java
@@ -1,11 +1,11 @@
 package dev.breeze.settlements.entities.villagers.sensors;
 
 import dev.breeze.settlements.entities.villagers.BaseVillager;
+import dev.breeze.settlements.utils.itemstack.ItemStackBuilder;
 import lombok.Getter;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
-import net.minecraft.world.entity.ai.sensing.Sensor;
 import net.minecraft.world.entity.npc.Villager;
 import net.minecraft.world.entity.schedule.Activity;
 
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Set;
 
 @Getter
-public abstract class VillagerNearbyBlockSensor extends Sensor<Villager> {
+public abstract class VillagerNearbyBlockSensor extends BaseVillagerSensor {
 
     /**
      * How far away to scan horizontally
@@ -48,25 +48,31 @@ public abstract class VillagerNearbyBlockSensor extends Sensor<Villager> {
     }
 
     @Override
-    protected final void doTick(@Nonnull ServerLevel world, @Nonnull Villager villager) {
-        Brain<Villager> brain = villager.getBrain();
-        if (!(villager instanceof BaseVillager baseVillager)) {
-            return;
-        }
-
+    protected void tickSensor(@Nonnull ServerLevel world, @Nonnull BaseVillager villager, @Nonnull Brain<Villager> brain) {
         // Check if current activity is allowed
         // - if allowed list is empty, we default to allowed
         if (!this.allowedActivities.isEmpty() && !this.allowedActivities.contains(brain.getSchedule().getActivityAt((int) world.getWorld().getTime()))) {
             return;
         }
 
-        this.tickSensor(world, baseVillager);
+        this.tickBlockSensor(world, villager, brain);
     }
 
-    protected abstract void tickSensor(@Nonnull ServerLevel world, @Nonnull BaseVillager villager);
+    protected abstract void tickBlockSensor(@Nonnull ServerLevel world, @Nonnull BaseVillager villager, @Nonnull Brain<Villager> brain);
 
     @Override
     @Nonnull
     public abstract Set<MemoryModuleType<?>> requires();
+
+    @Nonnull
+    public final ItemStackBuilder getGuiItemBuilderAbstract() {
+        ItemStackBuilder builder = this.getBaseGuiItemBuilder();
+        builder.appendLore("&fHorizontal range: %d blocks".formatted(this.rangeHorizontal));
+        builder.appendLore("&fVertical range: %d blocks".formatted(this.rangeVertical));
+        return builder;
+    }
+
+    @Nonnull
+    public abstract ItemStackBuilder getBaseGuiItemBuilder();
 
 }

--- a/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerNearbyEnchantingTableSensor.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerNearbyEnchantingTableSensor.java
@@ -3,13 +3,17 @@ package dev.breeze.settlements.entities.villagers.sensors;
 import dev.breeze.settlements.entities.villagers.BaseVillager;
 import dev.breeze.settlements.entities.villagers.memories.VillagerMemoryType;
 import dev.breeze.settlements.utils.TimeUtil;
+import dev.breeze.settlements.utils.itemstack.ItemStackBuilder;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.npc.Villager;
 import net.minecraft.world.entity.schedule.Activity;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.pathfinder.Path;
+import org.bukkit.Material;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -23,7 +27,7 @@ public class VillagerNearbyEnchantingTableSensor extends VillagerNearbyBlockSens
     }
 
     @Override
-    protected void tickSensor(@Nonnull ServerLevel world, @Nonnull BaseVillager villager) {
+    protected void tickBlockSensor(@Nonnull ServerLevel world, @Nonnull BaseVillager villager, @Nonnull Brain<Villager> brain) {
         // Detect nearby enchanting table
         Optional<BlockPos> enchantingTable = BlockPos.findClosestMatch(villager.blockPosition(), this.getRangeHorizontal(), this.getRangeVertical(), (pos) -> {
             // Check block state
@@ -36,13 +40,21 @@ public class VillagerNearbyEnchantingTableSensor extends VillagerNearbyBlockSens
             Path path = villager.getNavigation().createPath(pos, 2);
             return path != null;
         });
-        VillagerMemoryType.NEAREST_ENCHANTING_TABLE.set(villager.getBrain(), enchantingTable.orElse(null));
+        VillagerMemoryType.NEAREST_ENCHANTING_TABLE.set(brain, enchantingTable.orElse(null));
     }
 
     @Override
     @Nonnull
     public Set<MemoryModuleType<?>> requires() {
         return Set.of(VillagerMemoryType.NEAREST_ENCHANTING_TABLE.getMemoryModuleType());
+    }
+
+    @Nonnull
+    @Override
+    public ItemStackBuilder getBaseGuiItemBuilder() {
+        return new ItemStackBuilder(Material.ENCHANTING_TABLE)
+                .setDisplayName("&eNearest enchanting table sensor")
+                .setLore("&fInfrequently scans for the closest enchanting table");
     }
 
     public static boolean isEnchantingTable(BlockState state) {

--- a/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerNearbyHarvestableSugarcaneSensor.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerNearbyHarvestableSugarcaneSensor.java
@@ -3,13 +3,17 @@ package dev.breeze.settlements.entities.villagers.sensors;
 import dev.breeze.settlements.entities.villagers.BaseVillager;
 import dev.breeze.settlements.entities.villagers.memories.VillagerMemoryType;
 import dev.breeze.settlements.utils.TimeUtil;
+import dev.breeze.settlements.utils.itemstack.ItemStackBuilder;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
+import net.minecraft.world.entity.npc.Villager;
 import net.minecraft.world.entity.schedule.Activity;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.pathfinder.Path;
+import org.bukkit.Material;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -23,7 +27,7 @@ public class VillagerNearbyHarvestableSugarcaneSensor extends VillagerNearbyBloc
     }
 
     @Override
-    protected void tickSensor(@Nonnull ServerLevel world, @Nonnull BaseVillager villager) {
+    protected void tickBlockSensor(@Nonnull ServerLevel world, @Nonnull BaseVillager villager, @Nonnull Brain<Villager> brain) {
         // Detect nearby enchanting table
         Optional<BlockPos> enchantingTable = BlockPos.findClosestMatch(villager.blockPosition(), this.getRangeHorizontal(), this.getRangeVertical(), (pos) -> {
             // Check block state
@@ -35,13 +39,21 @@ public class VillagerNearbyHarvestableSugarcaneSensor extends VillagerNearbyBloc
             Path path = villager.getNavigation().createPath(pos, 2);
             return path != null;
         });
-        VillagerMemoryType.NEAREST_HARVESTABLE_SUGARCANE.set(villager.getBrain(), enchantingTable.orElse(null));
+        VillagerMemoryType.NEAREST_HARVESTABLE_SUGARCANE.set(brain, enchantingTable.orElse(null));
     }
 
     @Override
     @Nonnull
     public Set<MemoryModuleType<?>> requires() {
         return Set.of(VillagerMemoryType.NEAREST_HARVESTABLE_SUGARCANE.getMemoryModuleType());
+    }
+
+    @Nonnull
+    @Override
+    public ItemStackBuilder getBaseGuiItemBuilder() {
+        return new ItemStackBuilder(Material.SUGAR_CANE)
+                .setDisplayName("&eNearest sugar cane sensor")
+                .setLore("&fInfrequently scans for the closest harvestable sugar cane");
     }
 
     /**

--- a/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerNearbyWaterAreaSensor.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerNearbyWaterAreaSensor.java
@@ -3,13 +3,16 @@ package dev.breeze.settlements.entities.villagers.sensors;
 import dev.breeze.settlements.entities.villagers.BaseVillager;
 import dev.breeze.settlements.entities.villagers.memories.VillagerMemoryType;
 import dev.breeze.settlements.utils.TimeUtil;
+import dev.breeze.settlements.utils.itemstack.ItemStackBuilder;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.ai.Brain;
 import net.minecraft.world.entity.ai.memory.MemoryModuleType;
 import net.minecraft.world.entity.npc.Villager;
 import net.minecraft.world.entity.schedule.Activity;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.data.Levelled;
 import org.bukkit.craftbukkit.v1_19_R2.block.data.CraftBlockData;
@@ -26,10 +29,10 @@ public class VillagerNearbyWaterAreaSensor extends VillagerNearbyBlockSensor {
     }
 
     @Override
-    protected void tickSensor(@Nonnull ServerLevel world, @Nonnull BaseVillager villager) {
+    protected void tickBlockSensor(@Nonnull ServerLevel world, @Nonnull BaseVillager villager, @Nonnull Brain<Villager> brain) {
         // Detect nearby water areas
         Optional<BlockPos> nearestWaterArea = this.findNearestWaterArea(world, villager);
-        VillagerMemoryType.NEAREST_WATER_AREA.set(villager.getBrain(), nearestWaterArea.orElse(null));
+        VillagerMemoryType.NEAREST_WATER_AREA.set(brain, nearestWaterArea.orElse(null));
     }
 
     @Override
@@ -37,6 +40,15 @@ public class VillagerNearbyWaterAreaSensor extends VillagerNearbyBlockSensor {
     public Set<MemoryModuleType<?>> requires() {
         return Set.of(VillagerMemoryType.NEAREST_WATER_AREA.getMemoryModuleType());
     }
+
+    @Nonnull
+    @Override
+    public ItemStackBuilder getBaseGuiItemBuilder() {
+        return new ItemStackBuilder(Material.FISHING_ROD)
+                .setDisplayName("&eNearest fishable water area sensor")
+                .setLore("&fInfrequently scans for the closest water area that's big enough to fish");
+    }
+
 
     private Optional<BlockPos> findNearestWaterArea(@Nonnull ServerLevel world, @Nonnull Villager villager) {
         return BlockPos.findClosestMatch(villager.blockPosition(), this.getRangeHorizontal(), this.getRangeVertical(), (pos) -> {

--- a/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerSensor.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerSensor.java
@@ -1,0 +1,40 @@
+package dev.breeze.settlements.entities.villagers.sensors;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import net.minecraft.world.entity.ai.sensing.SensorType;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+import java.util.function.Supplier;
+
+public class VillagerSensor<T extends BaseVillagerSensor> {
+
+    /**
+     * A formatter for generating the identifier string, used as the Minecraft registry key
+     */
+    private static final String IDENTIFIER_FORMATTER = "settlements_villager_%s_sensor";
+
+    @Getter
+    @Nonnull
+    private final String identifier;
+
+    @Getter
+    private final Supplier<T> sensorSupplier;
+
+    @Getter
+    @Setter
+    private SensorType<T> sensorType;
+
+    @Builder
+    protected VillagerSensor(@Nonnull String identifier, @Nonnull Supplier<T> sensorSupplier) {
+        this.identifier = IDENTIFIER_FORMATTER.formatted(identifier);
+        this.sensorSupplier = sensorSupplier;
+    }
+
+    public ItemStack getGuiItem() {
+        return this.sensorSupplier.get().getGuiItemBuilder().build();
+    }
+
+}

--- a/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerSensorType.java
+++ b/src/main/java/dev/breeze/settlements/entities/villagers/sensors/VillagerSensorType.java
@@ -1,40 +1,62 @@
 package dev.breeze.settlements.entities.villagers.sensors;
 
-import net.minecraft.world.entity.ai.sensing.SensorType;
+import java.util.Arrays;
+import java.util.List;
 
 public class VillagerSensorType {
 
     /**
      * Sensor for scanning nearby water areas
      */
-    public static final String REGISTRY_KEY_NEAREST_WATER_AREA = "settlements_villager_nearest_water_area_sensor";
-    public static SensorType<VillagerNearbyWaterAreaSensor> NEAREST_WATER_AREA;
+    public static final VillagerSensor<VillagerNearbyWaterAreaSensor> NEAREST_WATER_AREA = VillagerSensor.<VillagerNearbyWaterAreaSensor>builder()
+            .identifier("nearest_water_area")
+            .sensorSupplier(VillagerNearbyWaterAreaSensor::new)
+            .build();
 
     /**
      * Sensor for meal time
-     * - breakfast: 1800-2200
-     * - lunch: 5800-6200
-     * - dinner: 10800-11200
      */
-    public static final String REGISTRY_KEY_IS_MEAL_TIME = "settlements_villager_is_meal_time_sensor";
-    public static SensorType<VillagerMealTimeSensor> IS_MEAL_TIME;
+    public static final VillagerSensor<VillagerMealTimeSensor> IS_MEAL_TIME = VillagerSensor.<VillagerMealTimeSensor>builder()
+            .identifier("is_meal_time")
+            .sensorSupplier(VillagerMealTimeSensor::new)
+            .build();
 
     /**
      * Sensor for scanning nearby enchanting tables
      */
-    public static final String REGISTRY_KEY_NEAREST_ENCHANTING_TABLE = "settlements_villager_nearest_enchanting_table_sensor";
-    public static SensorType<VillagerNearbyEnchantingTableSensor> NEAREST_ENCHANTING_TABLE;
+    public static final VillagerSensor<VillagerNearbyEnchantingTableSensor> NEAREST_ENCHANTING_TABLE =
+            VillagerSensor.<VillagerNearbyEnchantingTableSensor>builder()
+                    .identifier("nearest_enchanting_table")
+                    .sensorSupplier(VillagerNearbyEnchantingTableSensor::new)
+                    .build();
 
     /**
      * Sensor for scanning the closest harvestable sugarcane
      */
-    public static final String REGISTRY_KEY_NEAREST_HARVESTABLE_SUGARCANE = "settlements_villager_nearest_harvestable_sugarcane_sensor";
-    public static SensorType<VillagerNearbyHarvestableSugarcaneSensor> NEAREST_HARVESTABLE_SUGARCANE;
+    public static final VillagerSensor<VillagerNearbyHarvestableSugarcaneSensor> NEAREST_HARVESTABLE_SUGARCANE =
+            VillagerSensor.<VillagerNearbyHarvestableSugarcaneSensor>builder()
+                    .identifier("nearest_harvestable_sugarcane")
+                    .sensorSupplier(VillagerNearbyHarvestableSugarcaneSensor::new)
+                    .build();
 
     /**
      * Sensor for scanning the current habitat
      */
-    public static final String REGISTRY_KEY_CURRENT_HABITAT = "settlements_villager_current_habitat_sensor";
-    public static SensorType<VillagerHabitatSensor> CURRENT_HABITAT;
+    public static final VillagerSensor<VillagerHabitatSensor> CURRENT_HABITAT = VillagerSensor.<VillagerHabitatSensor>builder()
+            .identifier("current_habitat")
+            .sensorSupplier(VillagerHabitatSensor::new)
+            .build();
+
+    /**
+     * List of all memories for bulk memory operations such as save/load
+     */
+    public static final List<VillagerSensor<? extends BaseVillagerSensor>> ALL_SENSORS = Arrays.asList(
+            // Block sensors
+            NEAREST_WATER_AREA, NEAREST_HARVESTABLE_SUGARCANE, NEAREST_ENCHANTING_TABLE,
+            // Time sensors
+            IS_MEAL_TIME,
+            // Miscellaneous sensors
+            CURRENT_HABITAT
+    );
 
 }

--- a/src/main/java/dev/breeze/settlements/entities/wolves/VillagerWolf.java
+++ b/src/main/java/dev/breeze/settlements/entities/wolves/VillagerWolf.java
@@ -15,7 +15,7 @@ import dev.breeze.settlements.entities.wolves.goals.WolfMovementLockGoal;
 import dev.breeze.settlements.entities.wolves.goals.WolfSitWhenOrderedToGoal;
 import dev.breeze.settlements.entities.wolves.memories.WolfMemoryType;
 import dev.breeze.settlements.entities.wolves.sensors.WolfSensorType;
-import dev.breeze.settlements.utils.LogUtil;
+import dev.breeze.settlements.utils.DebugUtil;
 import it.unimi.dsi.fastutil.objects.Object2BooleanMap;
 import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 import lombok.Getter;
@@ -140,8 +140,14 @@ public class VillagerWolf extends Wolf {
     @Override
     public void load(@Nonnull CompoundTag nbt) {
         super.load(nbt);
-        LogUtil.info("Loading custom wolf...");
+        DebugUtil.log("Loading custom wolf (%s)", this.getUUID().toString());
         WolfMemoryType.load(nbt, this);
+    }
+
+    @Override
+    public boolean save(@Nonnull CompoundTag nbt) {
+        DebugUtil.log("Saving custom wolf (%s)", this.getUUID().toString());
+        return super.save(nbt);
     }
 
     /**
@@ -240,11 +246,11 @@ public class VillagerWolf extends Wolf {
      */
     private void registerBrainGoals(Brain<Wolf> brain) {
         if (this.getOwner() == null || !this.getOwner().isAlive()) {
-            LogUtil.warning("Skipping registration of wolf brain goals because owner is not available");
+            DebugUtil.log("Skipping initialization of wolf (%s) brain because owner is not available", this.getUUID().toString());
             return;
         }
 
-        LogUtil.info("Registering wolf brain goals");
+        DebugUtil.log("Initializing brain for wolf (%s)", this.getUUID().toString());
 
         // Set activity schedule
         // TODO: do we need to refine this?
@@ -332,10 +338,25 @@ public class VillagerWolf extends Wolf {
             return;
         }
 
-        LogUtil.info("Owner detected, refreshing wolf brain goals");
+        // Check base condition
+        if (this.getOwnerUUID() == null) {
+            return;
+        }
+
+        DebugUtil.log("Owner (%s) detected, refreshing wolf (%s) brain goals", this.getOwnerUUID().toString(), this.getUUID().toString());
         this.refreshBrain(this.level.getMinecraftWorld());
     }
 
+    /**
+     * Returns a short description of this villager wolf, primarily used in hover messages
+     */
+    public List<String> getHoverDescription() {
+        return List.of(
+                "Entity type: %s".formatted(ENTITY_TYPE),
+                "Owned by: %s".formatted(this.getOwner() == null ? "N/A" : this.getOwnerUUID().toString()),
+                "UUID: %s".formatted(this.getStringUUID())
+        );
+    }
 
     /*
      * Custom navigation for wolves to step over fences

--- a/src/main/java/dev/breeze/settlements/entities/wolves/behaviors/BaseWolfBehavior.java
+++ b/src/main/java/dev/breeze/settlements/entities/wolves/behaviors/BaseWolfBehavior.java
@@ -1,6 +1,7 @@
 package dev.breeze.settlements.entities.wolves.behaviors;
 
-import dev.breeze.settlements.utils.MessageUtil;
+import dev.breeze.settlements.entities.wolves.VillagerWolf;
+import dev.breeze.settlements.utils.DebugUtil;
 import dev.breeze.settlements.utils.TimeUtil;
 import lombok.Getter;
 import net.minecraft.server.level.ServerLevel;
@@ -34,7 +35,12 @@ public abstract class BaseWolfBehavior extends Behavior<Wolf> {
 
     @Override
     protected void start(@Nonnull ServerLevel level, @Nonnull Wolf wolf, long gameTime) {
-        MessageUtil.debug("&a[Debug] Wolf behavior " + this.getClass().getSimpleName() + " has started");
+        if (!(wolf instanceof VillagerWolf villagerWolf)) {
+            return;
+        }
+
+        DebugUtil.broadcastEntity("&aWolf behavior %s has started".formatted(this.getClass().getSimpleName()), wolf.getStringUUID(),
+                villagerWolf.getHoverDescription());
     }
 
     @Override
@@ -50,7 +56,12 @@ public abstract class BaseWolfBehavior extends Behavior<Wolf> {
 
     @Override
     protected void stop(@Nonnull ServerLevel level, @Nonnull Wolf wolf, long gameTime) {
-        MessageUtil.debug("&c[Debug] Wolf behavior " + this.getClass().getSimpleName() + " has stopped");
+        if (!(wolf instanceof VillagerWolf villagerWolf)) {
+            return;
+        }
+
+        DebugUtil.broadcastEntity("&cWolf behavior %s has stopped".formatted(this.getClass().getSimpleName()), wolf.getStringUUID(),
+                villagerWolf.getHoverDescription());
     }
 
 }

--- a/src/main/java/dev/breeze/settlements/test/TestCommandHandler.java
+++ b/src/main/java/dev/breeze/settlements/test/TestCommandHandler.java
@@ -33,45 +33,45 @@ public class TestCommandHandler implements TabExecutor {
     public boolean onCommand(@Nonnull CommandSender sender, @Nonnull Command command, @Nonnull String label, String[] args) {
         if (!(sender instanceof Player p)) {
             // Console command
-            MessageUtil.sendMessage(sender, "Go away evil console!!!");
+            MessageUtil.sendMessageWithPrefix(sender, "Go away evil console!!!");
             return true;
         }
 
-        if (!p.isOp()) {
-            // Admin-only command
-            MessageUtil.sendMessage(sender, "You must be an operator!");
+        // TODO: refactor permissions
+        // Check if the player has permission to execute the command
+        if (!p.hasPermission("settlements.admin")) {
+            MessageUtil.sendMessageWithPrefix(sender, "&cYou lack the required permission to use this command!");
         }
 
         String subCommand = args.length > 0 ? args[0].toLowerCase() : "basevillager";
-        MessageUtil.sendMessage(p, "Starting test execution...");
+        MessageUtil.sendMessageWithPrefix(p, "Starting test execution...");
         Block target = p.getTargetBlockExact(100);
 
         switch (subCommand) {
             case "basevillager" -> {
                 if (target == null) {
-                    MessageUtil.sendMessage(p, "&cInvalid block target!");
+                    MessageUtil.sendMessageWithPrefix(p, "&cInvalid block target!");
                 } else {
                     baseVillager(target, args);
                 }
             }
             case "armorstand" -> {
                 if (target == null) {
-                    MessageUtil.sendMessage(p, "&cInvalid block target!");
+                    MessageUtil.sendMessageWithPrefix(p, "&cInvalid block target!");
                 } else if (args.length != 4) {
-                    MessageUtil.sendMessage(p, "&cInvalid Arguments!");
+                    MessageUtil.sendMessageWithPrefix(p, "&cInvalid Arguments!");
                 } else {
                     armorstand(p, target, args);
                 }
             }
             case "advacement" -> advancement(p, args);
-            case "toggledebug" -> toggleDebug(p);
             default -> {
-                MessageUtil.sendMessage(p, "&cInvalid testing format!");
+                MessageUtil.sendMessageWithPrefix(p, "&cInvalid testing format!");
                 return true;
             }
         }
 
-        MessageUtil.sendMessage(p, "Test execution complete!");
+        MessageUtil.sendMessageWithPrefix(p, "Test execution complete!");
         return true;
     }
 
@@ -86,7 +86,6 @@ public class TestCommandHandler implements TabExecutor {
             tabComplete.add("BaseVillager");
             tabComplete.add("Armorstand");
             tabComplete.add("Advacement");
-            tabComplete.add("ToggleDebug");
         }
         return tabComplete.stream().filter(completion -> completion.toLowerCase().contains(args[args.length - 1].toLowerCase())).toList();
     }
@@ -99,7 +98,7 @@ public class TestCommandHandler implements TabExecutor {
         float pitch = Float.parseFloat(args[1]);
         float yaw = Float.parseFloat(args[2]);
         float roll = Float.parseFloat(args[3]);
-        MessageUtil.sendMessage(p, "&aPitch: %f, Yaw: %f, Roll: %f", pitch, yaw, roll);
+        MessageUtil.sendMessageWithPrefix(p, "&aPitch: %f, Yaw: %f, Roll: %f", pitch, yaw, roll);
 
         ServerLevel level = ((CraftWorld) p.getWorld()).getHandle();
         ArmorStand armorStand = new ArmorStand(level, target.getX(), target.getY() + 1, target.getZ());
@@ -113,10 +112,5 @@ public class TestCommandHandler implements TabExecutor {
     public static void advancement(Player p, String[] args) {
         Bukkit.getUnsafe().loadAdvancement(KeyUtils.newKey(""), "");
         Advancement advancement = Bukkit.getAdvancement(KeyUtils.newKey(""));
-    }
-
-    public static void toggleDebug(Player p) {
-        MessageUtil.toggleDebugging();
-        MessageUtil.sendMessage(p, MessageUtil.isDebugging() ? "&aEnabled Debugging!" : "&cDisabled Debugging");
     }
 }

--- a/src/main/java/dev/breeze/settlements/utils/BaseModuleController.java
+++ b/src/main/java/dev/breeze/settlements/utils/BaseModuleController.java
@@ -13,7 +13,7 @@ public abstract class BaseModuleController {
     public final boolean performPreload(JavaPlugin plugin) {
         try {
             boolean successful = this.preload(plugin);
-            LogUtil.info("Preloading \"%s\" %s!", getClass().getName(), (successful ? "succeeded" : "failed"));
+            DebugUtil.log("Preloading \"%s\" %s!", getClass().getName(), (successful ? "succeeded" : "failed"));
             return successful;
         } catch (Exception e) {
             LogUtil.exception(e, "Encountered exception while preloading %s module!", getClass().getName());
@@ -35,7 +35,7 @@ public abstract class BaseModuleController {
     public final boolean performLoad(JavaPlugin plugin, PluginManager pm) {
         try {
             boolean successful = this.load(plugin, pm);
-            LogUtil.info("Loading \"%s\" %s!", getClass().getName(), (successful ? "succeeded" : "failed"));
+            DebugUtil.log("Loading \"%s\" %s!", getClass().getName(), (successful ? "succeeded" : "failed"));
             return successful;
         } catch (Exception e) {
             LogUtil.exception(e, "Encountered exception while loading %s module!", getClass().getName());
@@ -54,7 +54,7 @@ public abstract class BaseModuleController {
     public final void performTeardown() {
         try {
             this.teardown();
-            LogUtil.info("Successfully torn down \"%s\" module!", getClass().getName());
+            DebugUtil.log("Successfully torn down \"%s\" module!", getClass().getName());
         } catch (Exception e) {
             LogUtil.exception(e, "Encountered exception while tearing down %s module!", getClass().getName());
         }

--- a/src/main/java/dev/breeze/settlements/utils/DebugUtil.java
+++ b/src/main/java/dev/breeze/settlements/utils/DebugUtil.java
@@ -1,0 +1,74 @@
+package dev.breeze.settlements.utils;
+
+import dev.breeze.settlements.config.files.GeneralConfig;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.hover.content.Text;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class DebugUtil {
+
+    @Getter
+    private static boolean debuggingEnabled = GeneralConfig.getInstance().getDebugEnabled().getValue();
+
+    public static void toggleDebugging() {
+        debuggingEnabled = !debuggingEnabled;
+        GeneralConfig.getInstance().getDebugEnabled().setValue(debuggingEnabled);
+    }
+
+    /**
+     * Broadcasts a colored and formatted message in the server, if debug is enabled
+     * - this message will only be sent to players with admin permissions
+     */
+    public static void broadcast(@Nonnull String message, @Nullable HoverEvent hoverEvent, @Nullable ClickEvent clickEvent) {
+        if (!debuggingEnabled) {
+            return;
+        }
+
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            // TODO: refactor permissions
+            if (player.hasPermission("settlements.admin")) {
+                // TODO: refactor strings & colors
+                MessageUtil.sendActionableMessage(player, "&7[&6S&eDebug&7] &r%s".formatted(message), hoverEvent, clickEvent);
+            }
+        }
+
+        // Log to console as well
+        log(message);
+    }
+
+    /**
+     * A shorthand method to broadcast an entity to all admin players
+     * - the hover action will display a teleport notice along with the hover messages
+     * - the click action will suggest to teleport to the entity
+     *
+     * @param message       The message to be broadcasted
+     * @param uuid          The UUID of the entity
+     * @param hoverMessages The list of hover messages to be displayed when hovering over the entity
+     */
+    public static void broadcastEntity(@Nonnull String message, @Nonnull String uuid, @Nonnull List<String> hoverMessages) {
+        String hoverMessage = "&e&lClick to teleport to the entity&r\n%s".formatted(String.join("\n", hoverMessages));
+        HoverEvent showEntity = new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(MessageUtil.translateColorCode(hoverMessage)));
+        ClickEvent suggestTeleport = new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/minecraft:tp %s".formatted(uuid));
+
+        broadcast(message, showEntity, suggestTeleport);
+    }
+
+    public static void log(String format, Object... args) {
+        if (!debuggingEnabled) {
+            return;
+        }
+
+        LogUtil.info(format, args);
+    }
+
+}

--- a/src/main/java/dev/breeze/settlements/utils/LogUtil.java
+++ b/src/main/java/dev/breeze/settlements/utils/LogUtil.java
@@ -15,6 +15,9 @@ public class LogUtil {
     public static void init(JavaPlugin plugin) {
         logger = plugin.getLogger();
         info("Hello (happy) world!");
+
+        // This is only sent if debugging is enabled, so it's safe to call
+        DebugUtil.log("You've enabled debugging mode, expect a LOT of log entries");
     }
 
     public static void info(String format, Object... args) {

--- a/src/main/java/dev/breeze/settlements/utils/MessageUtil.java
+++ b/src/main/java/dev/breeze/settlements/utils/MessageUtil.java
@@ -1,46 +1,57 @@
 package dev.breeze.settlements.utils;
 
-import dev.breeze.settlements.config.files.GeneralConfig;
-import lombok.Getter;
+import dev.breeze.settlements.Main;
 import net.md_5.bungee.api.ChatMessageType;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 public class MessageUtil {
 
-    @Getter
-    private static boolean debugging = GeneralConfig.getInstance().getDebugEnabled().getValue();
-
-    public static void toggleDebugging() {
-        debugging = !debugging;
-        GeneralConfig.getInstance().getDebugEnabled().setValue(debugging);
+    /**
+     * Sends a colored and formatted message containing the plugin's name as prefix to the target
+     * - color code '&' will be translated
+     */
+    public static void sendMessageWithPrefix(CommandSender target, String format, Object... args) {
+        target.sendMessage(translateColorCode("&7[&6%s&7] &r%s".formatted(Main.getPlugin().getName(), format.formatted(args))));
     }
 
     /**
-     * Sends a colored and formatted message to the target
+     * Sends a colored and formatted message without prefix to the target
      * - color code '&' will be translated
      */
-    public static void sendMessage(CommandSender target, String format, Object... args) {
+    public static void sendMessageWithoutPrefix(CommandSender target, String format, Object... args) {
         target.sendMessage(translateColorCode(String.format(format, args)));
     }
+
+    public static void sendActionableMessage(@Nonnull CommandSender target, @Nonnull String message,
+                                             @Nullable HoverEvent hoverEvent, @Nullable ClickEvent clickEvent) {
+        ComponentBuilder messageBuilder = new ComponentBuilder().appendLegacy(translateColorCode(message));
+        if (hoverEvent != null) {
+            messageBuilder.event(hoverEvent);
+        }
+        if (clickEvent != null) {
+            messageBuilder.event(clickEvent);
+        }
+
+        // TODO: if we want to make this bukkit-compatible, we might wanna change this
+        target.spigot().sendMessage(messageBuilder.create());
+    }
+
 
     /**
      * Broadcasts a colored and formatted message in the server
      */
     public static void broadcast(String format, Object... args) {
         Bukkit.broadcastMessage(translateColorCode(format, args));
-    }
-
-    /**
-     * Broadcasts a colored and formatted message in the server, if debug is enabled
-     */
-    public static void debug(String format, Object... args) {
-        if (debugging) {
-            broadcast(format, args);
-        }
     }
 
     public static String translateColorCode(String message) {

--- a/src/main/java/dev/breeze/settlements/utils/RayTraceUtil.java
+++ b/src/main/java/dev/breeze/settlements/utils/RayTraceUtil.java
@@ -1,0 +1,55 @@
+package dev.breeze.settlements.utils;
+
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntitySelector;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
+
+public class RayTraceUtil {
+
+    /**
+     * Mostly copied from paper
+     */
+    @Nullable
+    public static RayTraceResult getTargetEntity(Entity source, int maxDistance) {
+        if (maxDistance < 1 || maxDistance > 120) {
+            throw new IllegalArgumentException("maxDistance must be between 1-120");
+        }
+
+        Vec3 start = source.getEyePosition(1.0F);
+        Vec3 direction = source.getLookAngle();
+        Vec3 end = start.add(direction.x * maxDistance, direction.y * maxDistance, direction.z * maxDistance);
+
+        List<Entity> entityList = source.getLevel().getEntities(source, source.getBoundingBox()
+                .expandTowards(direction.x * maxDistance, direction.y * maxDistance, direction.z * maxDistance)
+                .inflate(1.0D, 1.0D, 1.0D), EntitySelector.NO_SPECTATORS.and(Entity::isPickable));
+
+        double distance = 0.0D;
+        RayTraceResult result = null;
+
+        for (Entity entity : entityList) {
+            final double inflationAmount = entity.getPickRadius();
+            AABB aabb = entity.getBoundingBox().inflate(inflationAmount, inflationAmount, inflationAmount);
+            Optional<Vec3> rayTraceResult = aabb.clip(start, end);
+
+            if (rayTraceResult.isPresent()) {
+                Vec3 rayTrace = rayTraceResult.get();
+                double distanceTo = start.distanceToSqr(rayTrace);
+                if (distanceTo < distance || distance == 0.0D) {
+                    result = new RayTraceResult(entity, distanceTo);
+                    distance = distanceTo;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public record RayTraceResult(Entity entity, double distance) {
+    }
+
+}

--- a/src/main/java/dev/breeze/settlements/utils/TimeUtil.java
+++ b/src/main/java/dev/breeze/settlements/utils/TimeUtil.java
@@ -48,6 +48,10 @@ public class TimeUtil {
             readableTime.append(ticks).append(" ticks");
         }
 
+        if (readableTime.isEmpty()) {
+            readableTime.append("0");
+        }
+
         return readableTime.toString().trim();
     }
 

--- a/src/main/java/dev/breeze/settlements/utils/TimeUtil.java
+++ b/src/main/java/dev/breeze/settlements/utils/TimeUtil.java
@@ -22,15 +22,15 @@ public class TimeUtil {
         return hours * HOUR_IN_TICKS;
     }
 
-    public static String ticksToReadableTime(int ticks) {
+    public static String ticksToReadableTime(long ticks) {
         // Split into time units
-        int hours = ticks / HOUR_IN_TICKS;
+        long hours = ticks / HOUR_IN_TICKS;
         ticks %= HOUR_IN_TICKS;
 
-        int minutes = ticks / MINUTE_IN_TICKS;
+        long minutes = ticks / MINUTE_IN_TICKS;
         ticks %= MINUTE_IN_TICKS;
 
-        int seconds = ticks / SECOND_IN_TICKS;
+        long seconds = ticks / SECOND_IN_TICKS;
         ticks %= SECOND_IN_TICKS;
 
         // Build the string


### PR DESCRIPTION
Cleaned up a lot of code
Nitwit pranks are now in appropriate activities instead of CORE
Villager sensors GUI is now part of the villager debug GUI
Debug logging is now using its own logging infrastructure instead of the general logger
Debug logging and broadcasting is now controlled by `/settlements_debug toggle` or `/sdebug toggle`
Console is no longer spammed at start up if debug mode is disabled

Broadcasted debug messages are now:
- hoverable: hovering shows you the basic info of the entity
- clickable: clicking teleports you to the entity

The debug stick can now ray trace to faraway entities and through walls